### PR TITLE
feat: can analyse package-lock.json in a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,8 @@ whatsdiff
 
 ## 📋 Roadmap
 Pull requests are welcome! Here are some ideas to get you started:
-- [x] Analyse composer.lock
-- [x] Find releases through packagist.com
-- [x] Analyse package-json.lock (javascript)
 - [ ] Make a nice TUI (WIP on [#1](https://github.com/SRWieZ/whatsdiff/pull/1))
+- [ ] Output format (json, markdown, no-ansi)
 - [ ] Retrieve changelog with Github API
 - [ ] Publish on NPM
 - [ ] Analyse gradle dependencies (android)


### PR DESCRIPTION
While working on https://github.com/NativePHP/electron/pull/147 and https://github.com/NativePHP/electron/pull/148, I noticed that we can't analyze the lock file in a subdirectory. 

Although this is an unusual case, it is now supported!