### PR TITLE
feat: implement PSR-11 compliant container and refactor commands to use dependency injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,15 +61,15 @@
       "./build.sh"
     ],
     "qa": [
-      "@composer static",
-      "@composer test"
+      "@static",
+      "@test"
     ],
     "static": [
-      "@composer pint",
-      "@composer phpstan"
+      "@pint",
+      "@phpstan"
     ],
     "box": "./vendor/bin/box",
-    "pint": "./vendor/bin/pint --preset psr12",
+    "pint": "./vendor/bin/pint --preset psr12 --parallel",
     "phpstan": "./vendor/bin/phpstan analyse",
     "test": "./vendor/bin/pest --parallel"
   }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "symfony/cache": "^6.0|^7.0",
     "symfony/filesystem": "^6.0|^7.0",
     "symfony/yaml": "^6.0|^7.0",
-    "guzzlehttp/guzzle": "^7.0"
+    "guzzlehttp/guzzle": "^7.0",
+    "psr/container": "^2.0"
   },
   "require-dev": {
     "pestphp/pest": "^2.0|^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1369,16 +1369,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.0",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "66c1440edf6f339fd82ed6c7caa76cb006211b44"
+                "reference": "9e27aecde8f506ba0fd1d9989620c04a87697101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/66c1440edf6f339fd82ed6c7caa76cb006211b44",
-                "reference": "66c1440edf6f339fd82ed6c7caa76cb006211b44",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9e27aecde8f506ba0fd1d9989620c04a87697101",
+                "reference": "9e27aecde8f506ba0fd1d9989620c04a87697101",
                 "shasum": ""
             },
             "require": {
@@ -1443,7 +1443,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.0"
+                "source": "https://github.com/symfony/console/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -1459,7 +1459,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-24T10:34:04+00:00"
+            "time": "2025-06-27T19:55:54+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4194,16 +4194,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "941d1927c5ca420c22710e98420287169c7bcaf7"
+                "reference": "9ab851dba4faa51a3c3223dd3d07044129021024"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/941d1927c5ca420c22710e98420287169c7bcaf7",
-                "reference": "941d1927c5ca420c22710e98420287169c7bcaf7",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/9ab851dba4faa51a3c3223dd3d07044129021024",
+                "reference": "9ab851dba4faa51a3c3223dd3d07044129021024",
                 "shasum": ""
             },
             "require": {
@@ -4214,10 +4214,10 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.75.0",
-                "illuminate/view": "^11.44.7",
-                "larastan/larastan": "^3.4.0",
-                "laravel-zero/framework": "^11.36.1",
+                "friendsofphp/php-cs-fixer": "^3.76.0",
+                "illuminate/view": "^11.45.1",
+                "larastan/larastan": "^3.5.0",
+                "laravel-zero/framework": "^11.45.0",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.3.1",
                 "pestphp/pest": "^2.36.0"
@@ -4227,6 +4227,9 @@
             ],
             "type": "project",
             "autoload": {
+                "files": [
+                    "overrides/Runner/Parallel/ProcessFactory.php"
+                ],
                 "psr-4": {
                     "App\\": "app/",
                     "Database\\Seeders\\": "database/seeders/",
@@ -4256,7 +4259,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-05-08T08:38:12+00:00"
+            "time": "2025-07-03T10:37:47+00:00"
         },
         {
             "name": "league/uri",
@@ -6067,21 +6070,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.8.1",
+            "version": "4.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28"
+                "reference": "4e0e23cc785f0724a0e838279a9eb03f28b092a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
-                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/4e0e23cc785f0724a0e838279a9eb03f28b092a0",
+                "reference": "4e0e23cc785f0724a0e838279a9eb03f28b092a0",
                 "shasum": ""
             },
             "require": {
                 "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13",
-                "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -6140,9 +6142,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.8.1"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
-            "time": "2025-06-01T06:28:46+00:00"
+            "time": "2025-06-25T14:20:11+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -7863,16 +7865,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.0",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "548f6760c54197b1084e1e5c71f6d9d523f2f78e"
+                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/548f6760c54197b1084e1e5c71f6d9d523f2f78e",
-                "reference": "548f6760c54197b1084e1e5c71f6d9d523f2f78e",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
+                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
                 "shasum": ""
             },
             "require": {
@@ -7927,7 +7929,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.0"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -7943,7 +7945,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-27T18:39:23+00:00"
+            "time": "2025-06-27T19:55:54+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d5fa146a07dc9123ad4c1ed06764ecc",
+    "content-hash": "4cb9f9abdbb59d0b9922656507195957",
     "packages": [
         {
             "name": "composer/semver",

--- a/src/Application.php
+++ b/src/Application.php
@@ -10,10 +10,14 @@ use Whatsdiff\Commands\CheckCommand;
 use Whatsdiff\Commands\ConfigCommand;
 use Whatsdiff\Commands\AnalyseCommand;
 use Whatsdiff\Commands\TuiCommand;
+use Whatsdiff\Container\Container;
+use Whatsdiff\Container\WhatsdiffServiceProvider;
 
 class Application extends BaseApplication
 {
     private const VERSION = '@git_tag@';
+
+    private Container $container;
 
     public function __construct()
     {
@@ -26,12 +30,21 @@ class Application extends BaseApplication
 
         parent::__construct('whatsdiff', self::getVersionString());
 
-        $this->add(new AnalyseCommand());
-        $this->add(new BetweenCommand());
-        $this->add(new TuiCommand());
-        $this->add(new CheckCommand());
-        $this->add(new ConfigCommand());
+        // Initialize container and register services
+        $this->container = new Container();
+        $this->container->register(new WhatsdiffServiceProvider());
+
+        $this->add(new AnalyseCommand($this->container));
+        $this->add(new BetweenCommand($this->container));
+        $this->add(new TuiCommand($this->container));
+        $this->add(new CheckCommand($this->container));
+        $this->add(new ConfigCommand($this->container));
         $this->setDefaultCommand('analyse');
+    }
+
+    public function getContainer(): Container
+    {
+        return $this->container;
     }
 
     public function getLongVersion(): string

--- a/src/Commands/AnalyseCommand.php
+++ b/src/Commands/AnalyseCommand.php
@@ -11,7 +11,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Whatsdiff\Analyzers\PackageManagerType;
 use Whatsdiff\Container\Container;
+use Whatsdiff\Outputs\JsonOutput;
+use Whatsdiff\Outputs\MarkdownOutput;
 use Whatsdiff\Outputs\OutputFormatterInterface;
+use Whatsdiff\Outputs\TextOutput;
 use Whatsdiff\Services\CacheService;
 use Whatsdiff\Services\DiffCalculator;
 
@@ -191,9 +194,11 @@ class AnalyseCommand extends Command
 
     private function getFormatter(string $format, bool $noAnsi): OutputFormatterInterface
     {
-        /** @var callable $formatterFactory */
-        $formatterFactory = $this->container->get('formatter.factory');
-        return $formatterFactory($format, ! $noAnsi);
+        return match ($format) {
+            'json' => new JsonOutput(),
+            'markdown' => new MarkdownOutput(),
+            default => new TextOutput(! $noAnsi),
+        };
     }
 
     private function shouldShowProgress($format, bool $noAnsi, InputInterface $input): bool

--- a/src/Commands/AnalyseCommand.php
+++ b/src/Commands/AnalyseCommand.php
@@ -9,19 +9,11 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Whatsdiff\Analyzers\ComposerAnalyzer;
-use Whatsdiff\Analyzers\NpmAnalyzer;
 use Whatsdiff\Analyzers\PackageManagerType;
-use Whatsdiff\Outputs\JsonOutput;
-use Whatsdiff\Outputs\MarkdownOutput;
+use Whatsdiff\Container\Container;
 use Whatsdiff\Outputs\OutputFormatterInterface;
-use Whatsdiff\Outputs\TextOutput;
 use Whatsdiff\Services\CacheService;
-use Whatsdiff\Services\ConfigService;
 use Whatsdiff\Services\DiffCalculator;
-use Whatsdiff\Services\GitRepository;
-use Whatsdiff\Services\HttpService;
-use Whatsdiff\Services\PackageInfoFetcher;
 
 use function Laravel\Prompts\clear;
 use function Laravel\Prompts\progress;
@@ -33,6 +25,13 @@ use function Laravel\Prompts\progress;
 )]
 class AnalyseCommand extends Command
 {
+    private Container $container;
+
+    public function __construct(Container $container)
+    {
+        parent::__construct();
+        $this->container = $container;
+    }
     /**
      * Get shared options that can be used by multiple commands
      */
@@ -127,21 +126,15 @@ class AnalyseCommand extends Command
         }
 
         try {
-            // Initialize services
-            $configService = new ConfigService();
-            $cacheService = new CacheService($configService);
+            // Get services from container
+            $cacheService = $this->container->get(CacheService::class);
+            /** @var DiffCalculator $diffCalculator */
+            $diffCalculator = $this->container->get(DiffCalculator::class);
 
             // Disable cache if requested
             if ($noCache) {
                 $cacheService->disableCache();
             }
-
-            $httpService = new HttpService($cacheService);
-            $git = new GitRepository();
-            $packageInfoFetcher = new PackageInfoFetcher($httpService);
-            $composerAnalyzer = new ComposerAnalyzer($packageInfoFetcher);
-            $npmAnalyzer = new NpmAnalyzer($packageInfoFetcher);
-            $diffCalculator = new DiffCalculator($git, $composerAnalyzer, $npmAnalyzer);
 
             // Parse dependency types from include/exclude options
             $dependencyTypes = $this->parseDependencyTypes($includeTypes, $excludeTypes, $output);
@@ -149,28 +142,25 @@ class AnalyseCommand extends Command
                 return Command::FAILURE;
             }
 
-            // Calculate diffs using fluent interface
-            $calculator = $diffCalculator;
-
             // Configure dependency types if specified
             foreach ($dependencyTypes as $type) {
-                $calculator = $calculator->for($type);
+                $diffCalculator->for($type);
             }
 
             if ($ignoreLast) {
-                $calculator = $calculator->ignoreLastCommit();
+                $diffCalculator->ignoreLastCommit();
             }
 
             if ($fromCommit !== null) {
-                $calculator = $calculator->fromCommit($fromCommit);
+                $diffCalculator->fromCommit($fromCommit);
             }
 
             if ($toCommit !== null) {
-                $calculator = $calculator->toCommit($toCommit);
+                $diffCalculator->toCommit($toCommit);
             }
 
             if ($this->shouldShowProgress($format, $noAnsi, $input)) {
-                [$total, $generator] = $calculator->run(withProgress: true);
+                [$total, $generator] = $diffCalculator->run(withProgress: true);
 
                 // Use Laravel Prompts for progress bar
                 if ($total) {
@@ -178,10 +168,10 @@ class AnalyseCommand extends Command
                     $this->showProgressBar($total, $generator);
                 }
 
-                $result = $calculator->getResult();
+                $result = $diffCalculator->getResult();
 
             } else {
-                $result = $calculator->run();
+                $result = $diffCalculator->run();
             }
 
             // Get appropriate formatter
@@ -201,11 +191,9 @@ class AnalyseCommand extends Command
 
     private function getFormatter(string $format, bool $noAnsi): OutputFormatterInterface
     {
-        return match ($format) {
-            'json' => new JsonOutput(),
-            'markdown' => new MarkdownOutput(),
-            default => new TextOutput(! $noAnsi),
-        };
+        /** @var callable $formatterFactory */
+        $formatterFactory = $this->container->get('formatter.factory');
+        return $formatterFactory($format, ! $noAnsi);
     }
 
     private function shouldShowProgress($format, bool $noAnsi, InputInterface $input): bool

--- a/src/Commands/BetweenCommand.php
+++ b/src/Commands/BetweenCommand.php
@@ -10,10 +10,19 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Whatsdiff\Container\Container;
 
 #[AsCommand(name: 'between')]
 class BetweenCommand extends Command
 {
+    /** @phpstan-ignore-next-line */
+    private Container $container;
+
+    public function __construct(Container $container)
+    {
+        parent::__construct();
+        $this->container = $container;
+    }
     protected function configure(): void
     {
         $this

--- a/src/Commands/ConfigCommand.php
+++ b/src/Commands/ConfigCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
+use Whatsdiff\Container\Container;
 use Whatsdiff\Services\ConfigService;
 
 #[AsCommand(
@@ -19,6 +20,13 @@ use Whatsdiff\Services\ConfigService;
 )]
 class ConfigCommand extends Command
 {
+    private Container $container;
+
+    public function __construct(Container $container)
+    {
+        parent::__construct();
+        $this->container = $container;
+    }
     protected function configure(): void
     {
         $this
@@ -38,7 +46,7 @@ class ConfigCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $configService = new ConfigService();
+        $configService = $this->container->get(ConfigService::class);
 
         $key = $input->getArgument('key');
         $value = $input->getArgument('value');

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Container;
+
+use Psr\Container\ContainerInterface;
+use Whatsdiff\Container\Exceptions\ContainerException;
+use Whatsdiff\Container\Exceptions\NotFoundException;
+
+class Container implements ContainerInterface
+{
+    private array $services = [];
+    private array $instances = [];
+    private array $singletons = [];
+
+    /**
+     * Register a service with the container
+     */
+    public function set(string $id, mixed $concrete, bool $singleton = false): void
+    {
+        $this->services[$id] = $concrete;
+
+        if ($singleton) {
+            $this->singletons[$id] = true;
+        }
+    }
+
+    /**
+     * Register a singleton service with the container
+     */
+    public function singleton(string $id, mixed $concrete): void
+    {
+        $this->set($id, $concrete, true);
+    }
+
+    /**
+     * Get a service from the container
+     */
+    public function get(string $id): mixed
+    {
+        if (!$this->has($id)) {
+            throw new NotFoundException("Service '{$id}' not found in container");
+        }
+
+        // Return existing singleton instance if available
+        if (isset($this->singletons[$id]) && isset($this->instances[$id])) {
+            return $this->instances[$id];
+        }
+
+        try {
+            $service = $this->services[$id];
+
+            // If service is a callable, invoke it
+            if (is_callable($service)) {
+                $instance = $service($this);
+            } else {
+                $instance = $service;
+            }
+
+            // Store singleton instances
+            if (isset($this->singletons[$id])) {
+                $this->instances[$id] = $instance;
+            }
+
+            return $instance;
+
+        } catch (\Throwable $e) {
+            throw new ContainerException("Error resolving service '{$id}': " . $e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * Check if a service exists in the container
+     */
+    public function has(string $id): bool
+    {
+        return isset($this->services[$id]);
+    }
+
+    /**
+     * Register a service provider with the container
+     */
+    public function register(ServiceProviderInterface $provider): void
+    {
+        $provider->register($this);
+    }
+}

--- a/src/Container/Exceptions/ContainerException.php
+++ b/src/Container/Exceptions/ContainerException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Container\Exceptions;
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class ContainerException extends Exception implements ContainerExceptionInterface
+{
+}

--- a/src/Container/Exceptions/NotFoundException.php
+++ b/src/Container/Exceptions/NotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Container\Exceptions;
+
+use Exception;
+use Psr\Container\NotFoundExceptionInterface;
+
+class NotFoundException extends Exception implements NotFoundExceptionInterface
+{
+}

--- a/src/Container/ServiceProviderInterface.php
+++ b/src/Container/ServiceProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Container;
+
+interface ServiceProviderInterface
+{
+    /**
+     * Register services with the container
+     */
+    public function register(Container $container): void;
+}

--- a/src/Container/WhatsdiffServiceProvider.php
+++ b/src/Container/WhatsdiffServiceProvider.php
@@ -6,10 +6,6 @@ namespace Whatsdiff\Container;
 
 use Whatsdiff\Analyzers\ComposerAnalyzer;
 use Whatsdiff\Analyzers\NpmAnalyzer;
-use Whatsdiff\Outputs\JsonOutput;
-use Whatsdiff\Outputs\MarkdownOutput;
-use Whatsdiff\Outputs\OutputFormatterInterface;
-use Whatsdiff\Outputs\TextOutput;
 use Whatsdiff\Services\CacheService;
 use Whatsdiff\Services\ConfigService;
 use Whatsdiff\Services\DiffCalculator;
@@ -64,30 +60,5 @@ class WhatsdiffServiceProvider implements ServiceProviderInterface
             );
         });
 
-        // Register output formatters
-        $container->set('formatter.text', function (Container $container) {
-            return function (bool $withAnsi = true): TextOutput {
-                return new TextOutput($withAnsi);
-            };
-        });
-
-        $container->set('formatter.json', function () {
-            return new JsonOutput();
-        });
-
-        $container->set('formatter.markdown', function () {
-            return new MarkdownOutput();
-        });
-
-        // Register formatter factory
-        $container->set('formatter.factory', function (Container $containerInstance) {
-            return function (string $format, bool $withAnsi = true) use ($containerInstance): OutputFormatterInterface {
-                return match ($format) {
-                    'json' => $containerInstance->get('formatter.json'),
-                    'markdown' => $containerInstance->get('formatter.markdown'),
-                    default => $containerInstance->get('formatter.text')($withAnsi),
-                };
-            };
-        });
     }
 }

--- a/src/Container/WhatsdiffServiceProvider.php
+++ b/src/Container/WhatsdiffServiceProvider.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Container;
+
+use Whatsdiff\Analyzers\ComposerAnalyzer;
+use Whatsdiff\Analyzers\NpmAnalyzer;
+use Whatsdiff\Outputs\JsonOutput;
+use Whatsdiff\Outputs\MarkdownOutput;
+use Whatsdiff\Outputs\OutputFormatterInterface;
+use Whatsdiff\Outputs\TextOutput;
+use Whatsdiff\Services\CacheService;
+use Whatsdiff\Services\ConfigService;
+use Whatsdiff\Services\DiffCalculator;
+use Whatsdiff\Services\GitRepository;
+use Whatsdiff\Services\HttpService;
+use Whatsdiff\Services\PackageInfoFetcher;
+
+class WhatsdiffServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $container): void
+    {
+        // Register configuration service as singleton
+        $container->singleton(ConfigService::class, function () {
+            return new ConfigService();
+        });
+
+        // Register cache service as singleton
+        $container->singleton(CacheService::class, function (Container $container) {
+            return new CacheService($container->get(ConfigService::class));
+        });
+
+        // Register HTTP service as singleton
+        $container->singleton(HttpService::class, function (Container $container) {
+            return new HttpService($container->get(CacheService::class));
+        });
+
+        // Register Git repository service as singleton
+        $container->singleton(GitRepository::class, function () {
+            return new GitRepository();
+        });
+
+        // Register package info fetcher as singleton
+        $container->singleton(PackageInfoFetcher::class, function (Container $container) {
+            return new PackageInfoFetcher($container->get(HttpService::class));
+        });
+
+        // Register analyzers as singletons
+        $container->singleton(ComposerAnalyzer::class, function (Container $container) {
+            return new ComposerAnalyzer($container->get(PackageInfoFetcher::class));
+        });
+
+        $container->singleton(NpmAnalyzer::class, function (Container $container) {
+            return new NpmAnalyzer($container->get(PackageInfoFetcher::class));
+        });
+
+        // Register diff calculator - not singleton as it might have different configurations
+        $container->set(DiffCalculator::class, function (Container $container) {
+            return new DiffCalculator(
+                $container->get(GitRepository::class),
+                $container->get(ComposerAnalyzer::class),
+                $container->get(NpmAnalyzer::class)
+            );
+        });
+
+        // Register output formatters
+        $container->set('formatter.text', function (Container $container) {
+            return function (bool $withAnsi = true): TextOutput {
+                return new TextOutput($withAnsi);
+            };
+        });
+
+        $container->set('formatter.json', function () {
+            return new JsonOutput();
+        });
+
+        $container->set('formatter.markdown', function () {
+            return new MarkdownOutput();
+        });
+
+        // Register formatter factory
+        $container->set('formatter.factory', function (Container $containerInstance) {
+            return function (string $format, bool $withAnsi = true) use ($containerInstance): OutputFormatterInterface {
+                return match ($format) {
+                    'json' => $containerInstance->get('formatter.json'),
+                    'markdown' => $containerInstance->get('formatter.markdown'),
+                    default => $containerInstance->get('formatter.text')($withAnsi),
+                };
+            };
+        });
+    }
+}

--- a/src/Services/DiffCalculator.php
+++ b/src/Services/DiffCalculator.php
@@ -131,15 +131,16 @@ class DiffCalculator
             // Just iterate through the generator to trigger the diff calculation
         }
 
-        return $this->diffResult;
+        // Ensure we always return a valid DiffResult, even if something went wrong
+        return $this->getResult();
     }
 
     /**
      * Get the result of the last run() call
      */
-    public function getResult(): ?DiffResult
+    public function getResult(): DiffResult
     {
-        return $this->diffResult;
+        return $this->diffResult ?? new DiffResult(collect(), false);
     }
 
     /**
@@ -187,6 +188,9 @@ class DiffCalculator
     private function processDiffsWithProgress(): \Generator
     {
         $diffs = collect();
+
+        // Initialize with empty result to ensure we always have a valid DiffResult
+        $this->diffResult = new DiffResult($diffs, false);
 
         // Handle custom commits case
         if ($this->fromCommit !== null || $this->toCommit !== null) {

--- a/tests/Unit/Container/PSR11ComplianceTest.php
+++ b/tests/Unit/Container/PSR11ComplianceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Whatsdiff\Container\Container;
+use Whatsdiff\Container\Exceptions\ContainerException;
+use Whatsdiff\Container\Exceptions\NotFoundException;
+
+describe('PSR-11 Compliance', function () {
+    it('implements ContainerInterface', function () {
+        $container = new Container();
+
+        expect($container)->toBeInstanceOf(ContainerInterface::class);
+    });
+
+    it('has method gets service by identifier', function () {
+        $container = new Container();
+        $service = new stdClass();
+        $container->set('test.service', $service);
+
+        $result = $container->get('test.service');
+
+        expect($result)->toBe($service);
+    });
+
+    it('has method returns true for existing services', function () {
+        $container = new Container();
+        $container->set('test.service', new stdClass());
+
+        expect($container->has('test.service'))->toBeTrue();
+    });
+
+    it('has method returns false for non-existing services', function () {
+        $container = new Container();
+
+        expect($container->has('non.existing.service'))->toBeFalse();
+    });
+
+    it('throws NotFoundExceptionInterface for non-existing services', function () {
+        $container = new Container();
+
+        try {
+            $container->get('non.existing.service');
+            expect(false)->toBeTrue('Expected NotFoundExceptionInterface to be thrown');
+        } catch (Exception $e) {
+            expect($e)->toBeInstanceOf(NotFoundExceptionInterface::class);
+        }
+    });
+
+    it('throws specific NotFoundException for non-existing services', function () {
+        $container = new Container();
+
+        try {
+            $container->get('non.existing.service');
+            expect(false)->toBeTrue('Expected NotFoundException to be thrown');
+        } catch (Exception $e) {
+            expect($e)->toBeInstanceOf(NotFoundException::class);
+        }
+    });
+
+    it('supports callable service factories', function () {
+        $container = new Container();
+        $container->set('test.service', fn () => new stdClass());
+
+        $result = $container->get('test.service');
+
+        expect($result)->toBeInstanceOf(stdClass::class);
+    });
+
+    it('supports singleton services', function () {
+        $container = new Container();
+        $container->singleton('test.singleton', fn () => new stdClass());
+
+        $first = $container->get('test.singleton');
+        $second = $container->get('test.singleton');
+
+        expect($first)->toBe($second);
+    });
+
+    it('injects container into factory functions', function () {
+        $container = new Container();
+        $container->set('dependency', new stdClass());
+        $container->set('test.service', fn (ContainerInterface $c) => $c->get('dependency'));
+
+        $result = $container->get('test.service');
+
+        expect($result)->toBeInstanceOf(stdClass::class);
+    });
+
+    it('throws ContainerException on factory errors', function () {
+        $container = new Container();
+        $container->set('failing.service', fn () => throw new RuntimeException('Factory error'));
+
+        try {
+            $container->get('failing.service');
+            expect(false)->toBeTrue('Expected ContainerException to be thrown');
+        } catch (Exception $e) {
+            expect($e)->toBeInstanceOf(ContainerException::class);
+        }
+    });
+});

--- a/tests/Unit/Container/PSR11InteroperabilityTest.php
+++ b/tests/Unit/Container/PSR11InteroperabilityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface;
+use Whatsdiff\Container\Container;
+
+describe('PSR-11 Interoperability', function () {
+    it('can be used as ContainerInterface type hint', function () {
+        $container = new Container();
+        $container->set('test.service', new stdClass());
+
+        $result = useContainerInterface($container);
+
+        expect($result)->toBeInstanceOf(stdClass::class);
+    });
+
+    it('works with dependency injection patterns', function () {
+        $container = new Container();
+
+        // Register a service that depends on another
+        $container->set('logger', fn () => new class () {
+            public function log(string $message): string
+            {
+                return "Logged: $message";
+            }
+        });
+
+        $container->set('service', fn (ContainerInterface $c) => new class ($c->get('logger')) {
+            public function __construct(private object $logger)
+            {
+            }
+
+            public function doSomething(): string
+            {
+                return $this->logger->log('Something happened');
+            }
+        });
+
+        $service = $container->get('service');
+        $result = $service->doSomething();
+
+        expect($result)->toBe('Logged: Something happened');
+    });
+
+    it('supports PSR-11 container composition', function () {
+        $container = new Container();
+        $container->set('name', 'whatsdiff');
+
+        // Another service that accepts a PSR-11 container
+        $service = new class ($container) {
+            public function __construct(private ContainerInterface $container)
+            {
+            }
+
+            public function getAppName(): string
+            {
+                return $this->container->get('name');
+            }
+        };
+
+        expect($service->getAppName())->toBe('whatsdiff');
+    });
+});
+
+/**
+ * Helper function that accepts any PSR-11 container
+ */
+function useContainerInterface(ContainerInterface $container): object
+{
+    return $container->get('test.service');
+}


### PR DESCRIPTION
This pull request introduces a dependency injection container to the `whatsdiff` project, replacing manual service initialization with container-based management.

* Custom `Container` class implementing `Psr\Container\ContainerInterface` with exception handling
* `ServiceProviderInterface` and `WhatsdiffServiceProvider` for service registration
* Updated commands to use container for dependency resolution
* Modified `Application` class to initialize and manage the container
* Added `psr/container` dependency for PSR-11 compliance
