### PR TITLE
feat: show semver level (minor, major, patch)

### DIFF
--- a/src/Commands/AnalyseCommand.php
+++ b/src/Commands/AnalyseCommand.php
@@ -212,7 +212,8 @@ class AnalyseCommand extends Command
 
         return $format == 'text' && $noAnsi === false
             && $input->isInteractive()
-            && ! $input->hasParameterOption('--no-progress');
+            && ! $input->hasParameterOption('--no-progress')
+            && ! $input->hasParameterOption('--no-interaction');
     }
 
     /**

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Whatsdiff\Container\Container;
-use Whatsdiff\Data\ChangeStatus;
+use Whatsdiff\Enums\ChangeStatus;
 use Whatsdiff\Enums\CheckType;
 use Whatsdiff\Services\DiffCalculator;
 

--- a/src/Container/WhatsdiffServiceProvider.php
+++ b/src/Container/WhatsdiffServiceProvider.php
@@ -12,6 +12,7 @@ use Whatsdiff\Services\DiffCalculator;
 use Whatsdiff\Services\GitRepository;
 use Whatsdiff\Services\HttpService;
 use Whatsdiff\Services\PackageInfoFetcher;
+use Whatsdiff\Services\SemverAnalyzer;
 
 class WhatsdiffServiceProvider implements ServiceProviderInterface
 {
@@ -51,12 +52,18 @@ class WhatsdiffServiceProvider implements ServiceProviderInterface
             return new NpmAnalyzer($container->get(PackageInfoFetcher::class));
         });
 
+        // Register semver analyzer as singleton
+        $container->singleton(SemverAnalyzer::class, function () {
+            return new SemverAnalyzer();
+        });
+
         // Register diff calculator - not singleton as it might have different configurations
         $container->set(DiffCalculator::class, function (Container $container) {
             return new DiffCalculator(
                 $container->get(GitRepository::class),
                 $container->get(ComposerAnalyzer::class),
-                $container->get(NpmAnalyzer::class)
+                $container->get(NpmAnalyzer::class),
+                $container->get(SemverAnalyzer::class)
             );
         });
 

--- a/src/Data/DependencyDiff.php
+++ b/src/Data/DependencyDiff.php
@@ -6,6 +6,7 @@ namespace Whatsdiff\Data;
 
 use Illuminate\Support\Collection;
 use Whatsdiff\Analyzers\PackageManagerType;
+use Whatsdiff\Enums\ChangeStatus;
 
 final readonly class DependencyDiff
 {

--- a/src/Data/PackageChange.php
+++ b/src/Data/PackageChange.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Whatsdiff\Data;
 
 use Whatsdiff\Analyzers\PackageManagerType;
+use Whatsdiff\Enums\ChangeStatus;
+use Whatsdiff\Enums\Semver;
 
 final readonly class PackageChange
 {
@@ -15,6 +17,7 @@ final readonly class PackageChange
         public ?string $to,
         public ChangeStatus $status,
         public ?int $releaseCount = null,
+        public ?Semver $semver = null,
     ) {
     }
 
@@ -45,7 +48,8 @@ final readonly class PackageChange
         PackageManagerType $type,
         string $fromVersion,
         string $toVersion,
-        ?int $releaseCount = null
+        ?int $releaseCount = null,
+        ?Semver $semver = null
     ): self {
         return new self(
             name: $name,
@@ -54,6 +58,7 @@ final readonly class PackageChange
             to: $toVersion,
             status: ChangeStatus::Updated,
             releaseCount: $releaseCount,
+            semver: $semver,
         );
     }
 
@@ -62,7 +67,8 @@ final readonly class PackageChange
         PackageManagerType $type,
         string $fromVersion,
         string $toVersion,
-        ?int $releaseCount = null
+        ?int $releaseCount = null,
+        ?Semver $semver = null
     ): self {
         return new self(
             name: $name,
@@ -71,6 +77,7 @@ final readonly class PackageChange
             to: $toVersion,
             status: ChangeStatus::Downgraded,
             releaseCount: $releaseCount,
+            semver: $semver,
         );
     }
 }

--- a/src/Enums/ChangeStatus.php
+++ b/src/Enums/ChangeStatus.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Whatsdiff\Data;
+namespace Whatsdiff\Enums;
 
 enum ChangeStatus: string
 {

--- a/src/Enums/Semver.php
+++ b/src/Enums/Semver.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Enums;
+
+enum Semver: string
+{
+    case Major = 'major';
+    case Minor = 'minor';
+    case Patch = 'patch';
+}

--- a/src/Outputs/JsonOutput.php
+++ b/src/Outputs/JsonOutput.php
@@ -27,6 +27,7 @@ class JsonOutput implements OutputFormatterInterface
                     'from' => $change->from,
                     'to' => $change->to,
                     'status' => $change->status->value,
+                    'semver' => $change->semver,
                     'release_count' => $change->releaseCount,
                 ])->toArray(),
             ])->toArray(),

--- a/src/Outputs/TextOutput.php
+++ b/src/Outputs/TextOutput.php
@@ -6,10 +6,10 @@ namespace Whatsdiff\Outputs;
 
 use Symfony\Component\Console\Output\OutputInterface;
 use Whatsdiff\Analyzers\PackageManagerType;
-use Whatsdiff\Data\ChangeStatus;
 use Whatsdiff\Data\DependencyDiff;
 use Whatsdiff\Data\DiffResult;
 use Whatsdiff\Data\PackageChange;
+use Whatsdiff\Enums\ChangeStatus;
 
 class TextOutput implements OutputFormatterInterface
 {

--- a/src/Outputs/TextOutput.php
+++ b/src/Outputs/TextOutput.php
@@ -11,24 +11,21 @@ use Whatsdiff\Data\DiffResult;
 use Whatsdiff\Data\PackageChange;
 use Whatsdiff\Enums\ChangeStatus;
 use Whatsdiff\Enums\Semver;
-use Whatsdiff\Services\VersionHighlighter;
 
 class TextOutput implements OutputFormatterInterface
 {
     private bool $useAnsi;
-    private VersionHighlighter $versionHighlighter;
 
     public function __construct(bool $useAnsi = true)
     {
         $this->useAnsi = $useAnsi;
-        $this->versionHighlighter = new VersionHighlighter();
     }
 
     public function format(DiffResult $result, OutputInterface $output): void
     {
-        if ( ! $result->hasDiffs()) {
+        if (! $result->hasDiffs()) {
             $filenameList = collect(PackageManagerType::cases())
-                ->map(fn($type) => $type->getLockFileName())
+                ->map(fn ($type) => $type->getLockFileName())
                 ->implode(', ');
             $output->writeln("No recent changes and no commit logs found for {$filenameList}");
 
@@ -60,7 +57,7 @@ class TextOutput implements OutputFormatterInterface
         }
         $output->writeln('');
 
-        if ( ! $diff->hasChanges()) {
+        if (! $diff->hasChanges()) {
             $output->writeln(' → No dependencies changes detected');
             $output->writeln('');
 
@@ -80,13 +77,13 @@ class TextOutput implements OutputFormatterInterface
         }
 
         // Calculate padding for alignment
-        $maxNameLen = $diff->changes->max(fn(PackageChange $c) => strlen($c->name)) ?: 0;
+        $maxNameLen = $diff->changes->max(fn (PackageChange $c) => strlen($c->name)) ?: 0;
         $maxFromLen = $diff->changes
-            ->filter(fn(PackageChange $c) => $c->from !== null)
-            ->max(fn(PackageChange $c) => strlen($c->from)) ?: 0;
+            ->filter(fn (PackageChange $c) => $c->from !== null)
+            ->max(fn (PackageChange $c) => strlen($c->from)) ?: 0;
         $maxToLen = $diff->changes
-            ->filter(fn(PackageChange $c) => $c->to !== null)
-            ->max(fn(PackageChange $c) => strlen($c->to)) ?: 0;
+            ->filter(fn (PackageChange $c) => $c->to !== null)
+            ->max(fn (PackageChange $c) => strlen($c->to)) ?: 0;
 
         foreach ($changes as $change) {
             $symbol = $this->getSymbol($change->status, $change->semver);
@@ -146,7 +143,7 @@ class TextOutput implements OutputFormatterInterface
 
         $symbol = mb_str_pad($symbol, 4, ' ', STR_PAD_LEFT);
 
-        if ( ! $this->useAnsi) {
+        if (! $this->useAnsi) {
             return $symbol;
         }
 

--- a/src/Services/DiffCalculator.php
+++ b/src/Services/DiffCalculator.php
@@ -33,7 +33,8 @@ class DiffCalculator
     public function __construct(
         GitRepository $git,
         ComposerAnalyzer $composerAnalyzer,
-        NpmAnalyzer $npmAnalyzer
+        NpmAnalyzer $npmAnalyzer,
+        private readonly SemverAnalyzer $semverAnalyzer
     ) {
         $this->git = $git;
         $this->composerAnalyzer = $composerAnalyzer;
@@ -433,6 +434,7 @@ class DiffCalculator
         // Both versions exist - either updated or downgraded
         if ($infos['from'] !== null && $infos['to'] !== null) {
             $releasesCount = $skipReleaseCount ? null : $this->getReleasesCount($type, $package, $infos);
+            $semverChangeType = $this->semverAnalyzer->determineSemverChangeType($infos['from'], $infos['to']);
 
             if (Comparator::greaterThan($infos['to'], $infos['from'])) {
                 return PackageChange::updated(
@@ -441,6 +443,7 @@ class DiffCalculator
                     fromVersion: $infos['from'],
                     toVersion: $infos['to'],
                     releaseCount: $releasesCount,
+                    semver: $semverChangeType,
                 );
             } else {
                 return PackageChange::downgraded(
@@ -449,6 +452,7 @@ class DiffCalculator
                     fromVersion: $infos['from'],
                     toVersion: $infos['to'],
                     releaseCount: $releasesCount,
+                    semver: $semverChangeType,
                 );
             }
         }

--- a/src/Services/SemverAnalyzer.php
+++ b/src/Services/SemverAnalyzer.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Services;
+
+use Composer\Semver\VersionParser;
+use Whatsdiff\Enums\Semver;
+
+final class SemverAnalyzer
+{
+    private readonly VersionParser $versionParser;
+
+    public function __construct()
+    {
+        $this->versionParser = new VersionParser();
+    }
+
+    public function determineSemverChangeType(string $fromVersion, string $toVersion): ?Semver
+    {
+        // Check for dev versions that shouldn't be analyzed
+        if ($this->isDevVersion($fromVersion) || $this->isDevVersion($toVersion)) {
+            return null;
+        }
+
+        $fromParts = $this->parseVersion($fromVersion);
+        $toParts = $this->parseVersion($toVersion);
+
+        if ($fromParts === null || $toParts === null) {
+            return null;
+        }
+
+        if ($fromParts['major'] !== $toParts['major']) {
+            return Semver::Major;
+        }
+
+        if ($fromParts['minor'] !== $toParts['minor']) {
+            return Semver::Minor;
+        }
+
+        if ($fromParts['patch'] !== $toParts['patch']) {
+            return Semver::Patch;
+        }
+
+        return null;
+    }
+
+    private function parseVersion(string $version): ?array
+    {
+        try {
+            $normalized = $this->versionParser->normalize($version);
+        } catch (\UnexpectedValueException) {
+            return null;
+        }
+
+        if (! preg_match('/^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?(?:\+(.+))?$/', $normalized, $matches)) {
+            return null;
+        }
+
+        return [
+            'major' => (int) $matches[1],
+            'minor' => (int) $matches[2],
+            'patch' => (int) $matches[3],
+        ];
+    }
+
+    private function isDevVersion(string $version): bool
+    {
+        return $this->versionParser->parseStability($version) === 'dev';
+    }
+}

--- a/tests/Architecture/ArchitecturalTest.php
+++ b/tests/Architecture/ArchitecturalTest.php
@@ -49,5 +49,4 @@ arch('data classes are readonly and final')
     ->expect('Whatsdiff\Data')
     ->classes()
     ->toBeReadonly()
-    ->toBeFinal()
-    ->ignoring('Whatsdiff\Data\ChangeStatus');
+    ->toBeFinal();

--- a/tests/Unit/Data/PackageChangeTest.php
+++ b/tests/Unit/Data/PackageChangeTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use Whatsdiff\Analyzers\PackageManagerType;
+use Whatsdiff\Data\PackageChange;
+use Whatsdiff\Enums\ChangeStatus;
+use Whatsdiff\Enums\Semver;
+
+describe('PackageChange', function () {
+    test('creates updated package with semver data', function () {
+        $change = PackageChange::updated(
+            name: 'symfony/console',
+            type: PackageManagerType::COMPOSER,
+            fromVersion: 'v5.4.0',
+            toVersion: 'v6.0.0',
+            releaseCount: 5,
+            semver: Semver::Major
+        );
+
+        expect($change->name)->toBe('symfony/console')
+            ->and($change->type)->toBe(PackageManagerType::COMPOSER)
+            ->and($change->from)->toBe('v5.4.0')
+            ->and($change->to)->toBe('v6.0.0')
+            ->and($change->status)->toBe(ChangeStatus::Updated)
+            ->and($change->releaseCount)->toBe(5)
+            ->and($change->semver)->toBe(Semver::Major);
+    });
+
+    test('creates downgraded package with semver data', function () {
+        $change = PackageChange::downgraded(
+            name: 'laravel/framework',
+            type: PackageManagerType::COMPOSER,
+            fromVersion: 'v9.0.0',
+            toVersion: 'v8.0.0',
+            releaseCount: 3,
+            semver: Semver::Major
+        );
+
+        expect($change->semver)->toBe(Semver::Major)
+            ->and($change->status)->toBe(ChangeStatus::Downgraded)
+            ->and($change->from)->toBe('v9.0.0')
+            ->and($change->to)->toBe('v8.0.0');
+    });
+
+    test('added packages have no semver data', function () {
+        $change = PackageChange::added(
+            name: 'new/package',
+            type: PackageManagerType::COMPOSER,
+            version: 'v1.0.0'
+        );
+
+        expect($change->semver)->toBeNull()
+            ->and($change->from)->toBeNull()
+            ->and($change->status)->toBe(ChangeStatus::Added);
+    });
+
+    test('removed packages have no semver data', function () {
+        $change = PackageChange::removed(
+            name: 'old/package',
+            type: PackageManagerType::COMPOSER,
+            version: 'v1.0.0'
+        );
+
+        expect($change->semver)->toBeNull()
+            ->and($change->to)->toBeNull()
+            ->and($change->status)->toBe(ChangeStatus::Removed);
+    });
+
+    test('updated package can have null semver for non-semver versions', function () {
+        $change = PackageChange::updated(
+            name: 'test/package',
+            type: PackageManagerType::COMPOSER,
+            fromVersion: 'dev-main',
+            toVersion: 'dev-feature',
+            releaseCount: null,
+            semver: null
+        );
+
+        expect($change->semver)->toBeNull()
+            ->and($change->status)->toBe(ChangeStatus::Updated);
+    });
+
+    test('downgraded package can have null semver for non-semver versions', function () {
+        $change = PackageChange::downgraded(
+            name: 'test/package',
+            type: PackageManagerType::COMPOSER,
+            fromVersion: 'dev-feature',
+            toVersion: 'dev-main',
+            releaseCount: null,
+            semver: null
+        );
+
+        expect($change->semver)->toBeNull()
+            ->and($change->status)->toBe(ChangeStatus::Downgraded);
+    });
+
+    test('supports different semver change types', function () {
+        $majorChange = PackageChange::updated(
+            name: 'test/package',
+            type: PackageManagerType::COMPOSER,
+            fromVersion: '1.0.0',
+            toVersion: '2.0.0',
+            semver: Semver::Major
+        );
+
+        $minorChange = PackageChange::updated(
+            name: 'test/package',
+            type: PackageManagerType::COMPOSER,
+            fromVersion: '1.0.0',
+            toVersion: '1.1.0',
+            semver: Semver::Minor
+        );
+
+        $patchChange = PackageChange::updated(
+            name: 'test/package',
+            type: PackageManagerType::COMPOSER,
+            fromVersion: '1.0.0',
+            toVersion: '1.0.1',
+            semver: Semver::Patch
+        );
+
+        expect($majorChange->semver)->toBe(Semver::Major)
+            ->and($minorChange->semver)->toBe(Semver::Minor)
+            ->and($patchChange->semver)->toBe(Semver::Patch);
+    });
+
+    test('supports NPM package manager type', function () {
+        $change = PackageChange::updated(
+            name: 'lodash',
+            type: PackageManagerType::NPM,
+            fromVersion: '4.0.0',
+            toVersion: '4.1.0',
+            semver: Semver::Minor
+        );
+
+        expect($change->type)->toBe(PackageManagerType::NPM)
+            ->and($change->semver)->toBe(Semver::Minor);
+    });
+});

--- a/tests/Unit/Services/SemverAnalyzerTest.php
+++ b/tests/Unit/Services/SemverAnalyzerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Whatsdiff\Enums\Semver;
+use Whatsdiff\Services\SemverAnalyzer;
+
+beforeEach(function () {
+    $this->analyzer = new SemverAnalyzer();
+});
+
+describe('SemverAnalyzer', function () {
+    test('determines major version change', function () {
+        $result = $this->analyzer->determineSemverChangeType('1.0.0', '2.0.0');
+        expect($result)->toBe(Semver::Major);
+    });
+
+    test('determines minor version change', function () {
+        $result = $this->analyzer->determineSemverChangeType('1.0.0', '1.1.0');
+        expect($result)->toBe(Semver::Minor);
+    });
+
+    test('determines patch version change', function () {
+        $result = $this->analyzer->determineSemverChangeType('1.0.0', '1.0.1');
+        expect($result)->toBe(Semver::Patch);
+    });
+
+    test('handles downgrade scenarios', function () {
+        expect($this->analyzer->determineSemverChangeType('2.0.0', '1.0.0'))->toBe(Semver::Major);
+        expect($this->analyzer->determineSemverChangeType('1.1.0', '1.0.0'))->toBe(Semver::Minor);
+        expect($this->analyzer->determineSemverChangeType('1.0.1', '1.0.0'))->toBe(Semver::Patch);
+    });
+
+    test('handles complex version strings', function () {
+        expect($this->analyzer->determineSemverChangeType('1.0.0', '2.0.0-beta.1'))->toBe(Semver::Major);
+        expect($this->analyzer->determineSemverChangeType('1.0.0', '1.1.0-alpha'))->toBe(Semver::Minor);
+        expect($this->analyzer->determineSemverChangeType('1.0.0', '1.0.1-rc.1'))->toBe(Semver::Patch);
+    });
+
+    test('handles version prefixes', function () {
+        expect($this->analyzer->determineSemverChangeType('v1.0.0', 'v2.0.0'))->toBe(Semver::Major);
+        expect($this->analyzer->determineSemverChangeType('v1.0.0', 'v1.1.0'))->toBe(Semver::Minor);
+        expect($this->analyzer->determineSemverChangeType('v1.0.0', 'v1.0.1'))->toBe(Semver::Patch);
+    });
+
+    test('handles four-digit versions', function () {
+        expect($this->analyzer->determineSemverChangeType('1.0.0.0', '2.0.0.0'))->toBe(Semver::Major);
+        expect($this->analyzer->determineSemverChangeType('1.0.0.0', '1.1.0.0'))->toBe(Semver::Minor);
+        expect($this->analyzer->determineSemverChangeType('1.0.0.0', '1.0.1.0'))->toBe(Semver::Patch);
+    });
+
+    test('returns null for identical versions', function () {
+        $result = $this->analyzer->determineSemverChangeType('1.0.0', '1.0.0');
+        expect($result)->toBeNull();
+    });
+
+    test('returns null for invalid versions', function () {
+        expect($this->analyzer->determineSemverChangeType('invalid', '1.0.0'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('1.0.0', 'invalid'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('invalid', 'invalid'))->toBeNull();
+    });
+
+    test('returns null for non-semver versions', function () {
+        expect($this->analyzer->determineSemverChangeType('dev-main', '1.0.0'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('1.0.0', 'dev-main'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('1.x-dev', '2.x-dev'))->toBeNull();
+    });
+
+    test('handles composer branch aliases', function () {
+        expect($this->analyzer->determineSemverChangeType('1.0.x-dev', '1.1.x-dev'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('dev-master', 'dev-main'))->toBeNull();
+    });
+
+    test('handles pre-release versions correctly', function () {
+        expect($this->analyzer->determineSemverChangeType('1.0.0-alpha', '1.0.0'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('1.0.0-alpha.1', '1.0.0-beta.1'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('1.0.0-rc.1', '1.0.0'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('1.0.0-alpha', '2.0.0'))->toBe(Semver::Major);
+        expect($this->analyzer->determineSemverChangeType('1.0.0', '1.1.0-beta'))->toBe(Semver::Minor);
+    });
+
+    test('handles build metadata', function () {
+        expect($this->analyzer->determineSemverChangeType('1.0.0+build.1', '1.0.0+build.2'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('1.0.0', '1.0.0+build.1'))->toBeNull();
+        expect($this->analyzer->determineSemverChangeType('1.0.0+build.1', '1.0.1+build.1'))->toBe(Semver::Patch);
+    });
+
+    test('prioritizes highest level change', function () {
+        expect($this->analyzer->determineSemverChangeType('1.0.0', '2.1.1'))->toBe(Semver::Major);
+        expect($this->analyzer->determineSemverChangeType('1.0.0', '1.1.1'))->toBe(Semver::Minor);
+    });
+
+    test('handles edge case versions', function () {
+        expect($this->analyzer->determineSemverChangeType('0.0.1', '0.0.2'))->toBe(Semver::Patch);
+        expect($this->analyzer->determineSemverChangeType('0.1.0', '0.2.0'))->toBe(Semver::Minor);
+        expect($this->analyzer->determineSemverChangeType('0.1.0', '1.0.0'))->toBe(Semver::Major);
+    });
+});


### PR DESCRIPTION
This pull request enhances semantic versioning (Semver) support, output formatting, and dependency management. Key changes include:

### Semantic Versioning Enhancements:
* Added `Semver` enum to represent version changes
* Integrated `SemverAnalyzer` into `DiffCalculator` to determine version change types
* Updated `PackageChange` to include Semver property

### Output Formatting Improvements:
* Enhanced `MarkdownOutput` to display dependencies with Semver badges
* Updated `TextOutput` to align versions and include Semver symbols
* Modified `JsonOutput` to include Semver property

### Dependency Management and Refactors:
* Registered `SemverAnalyzer` as a singleton
* Renamed `ChangeStatus` and updated namespace references
* Updated imports across multiple files

### Minor Improvements:
* Enhanced `AnalyseCommand` to respect `--no-interaction` flag