### PR TITLE
Harden GitHub Actions workflows against token disclosure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @SRWieZ

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-linux-arm-binary.yml
+++ b/.github/workflows/build-linux-arm-binary.yml
@@ -6,8 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BINARY_NAME: 'whatsdiff-linux-aarch64'
   BINARY_MCP_NAME: 'whatsdiff-mcp-linux-aarch64'
   COMPILE_PHP_VERSION: "8.4"
@@ -21,19 +22,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: ${{ env.COMPILE_PHP_VERSION }}
           tools: composer:v2
 
       - name: Cache build dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/
           key: build-deps-php${{ env.COMPILE_PHP_VERSION }}-${{ runner.os }}-${{ runner.arch }}
@@ -43,7 +45,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -57,21 +59,21 @@ jobs:
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload whatsdiff binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_NAME }}
           path: build/bin/${{ env.BINARY_NAME }}
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload whatsdiff-mcp binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_MCP_NAME }}
           path: build/bin/${{ env.BINARY_MCP_NAME }}
 
       - if: ${{ github.event_name != 'workflow_dispatch' }}
         name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.1
         with:
           files: |
             build/bin/${{ env.BINARY_NAME }}

--- a/.github/workflows/build-linux-binary.yml
+++ b/.github/workflows/build-linux-binary.yml
@@ -6,8 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BINARY_NAME: 'whatsdiff-linux-x86_64'
   BINARY_MCP_NAME: 'whatsdiff-mcp-linux-x86_64'
   COMPILE_PHP_VERSION: "8.4"
@@ -21,19 +22,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Cache build dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/
           key: build-deps-php${{ env.COMPILE_PHP_VERSION }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: ${{ env.COMPILE_PHP_VERSION }}
           tools: composer:v2
@@ -43,7 +45,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -57,21 +59,21 @@ jobs:
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload whatsdiff binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_NAME }}
           path: build/bin/${{ env.BINARY_NAME }}
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload whatsdiff-mcp binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_MCP_NAME }}
           path: build/bin/${{ env.BINARY_MCP_NAME }}
 
       - if: ${{ github.event_name != 'workflow_dispatch' }}
         name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.1
         with:
           files: |
             build/bin/${{ env.BINARY_NAME }}

--- a/.github/workflows/build-macos-arm-binary.yml
+++ b/.github/workflows/build-macos-arm-binary.yml
@@ -6,8 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BINARY_NAME: 'whatsdiff-macos-arm64'
   BINARY_MCP_NAME: 'whatsdiff-mcp-macos-arm64'
   COMPILE_PHP_VERSION: "8.4"
@@ -21,10 +22,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Install macOS missing packages and mark os suffix
         run: |
@@ -32,13 +34,13 @@ jobs:
           echo "SPC_BUILD_OS=macos" >> $GITHUB_ENV
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: ${{ env.COMPILE_PHP_VERSION }}
           tools: composer:v2
 
       - name: Cache build dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/
           key: build-deps-php${{ env.COMPILE_PHP_VERSION }}-${{ runner.os }}-${{ runner.arch }}
@@ -48,7 +50,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -62,21 +64,21 @@ jobs:
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload whatsdiff binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_NAME }}
           path: build/bin/${{ env.BINARY_NAME }}
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload whatsdiff-mcp binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_MCP_NAME }}
           path: build/bin/${{ env.BINARY_MCP_NAME }}
 
       - if: ${{ github.event_name != 'workflow_dispatch' }}
         name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.1
         with:
           files: |
             build/bin/${{ env.BINARY_NAME }}

--- a/.github/workflows/build-macos-binary.yml
+++ b/.github/workflows/build-macos-binary.yml
@@ -6,8 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BINARY_NAME: 'whatsdiff-macos-x86_64'
   BINARY_MCP_NAME: 'whatsdiff-mcp-macos-x86_64'
   COMPILE_PHP_VERSION: "8.4"
@@ -21,18 +22,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Install macOS missing packages and mark os suffix
         run: |
-          brew install automake gzip 
+          brew install automake gzip
           echo "SPC_BUILD_OS=macos" >> $GITHUB_ENV
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: ${{ env.COMPILE_PHP_VERSION }}
           tools: pecl, composer
@@ -40,7 +42,7 @@ jobs:
           ini-values: memory_limit=-1
 
       - name: Cache build dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/
           key: build-deps-php${{ env.COMPILE_PHP_VERSION }}-${{ runner.os }}-${{ runner.arch }}
@@ -50,7 +52,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -64,21 +66,21 @@ jobs:
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload whatsdiff binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_NAME }}
           path: build/bin/${{ env.BINARY_NAME }}
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload whatsdiff-mcp binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_MCP_NAME }}
           path: build/bin/${{ env.BINARY_MCP_NAME }}
 
       - if: ${{ github.event_name != 'workflow_dispatch' }}
         name: Upload binaries to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.1
         with:
           files: |
             build/bin/${{ env.BINARY_NAME }}

--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -3,6 +3,8 @@ on:
   release:
     types: [ created ]
 
+permissions: {}
+
 jobs:
   build-phar:
     runs-on: ubuntu-latest
@@ -12,13 +14,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: "8.4"
           tools: composer:v2
@@ -28,7 +31,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -44,7 +47,7 @@ jobs:
         run: composer box
 
       - name: Upload PHARs to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.1
         with:
           files: |
             build/bin/whatsdiff.phar

--- a/.github/workflows/build-windows-binary.yml
+++ b/.github/workflows/build-windows-binary.yml
@@ -6,8 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BINARY_NAME: 'whatsdiff-windows-x86_64.exe'
   COMPILE_PHP_VERSION: "8.4"
 
@@ -20,19 +21,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: ${{ env.COMPILE_PHP_VERSION }}
           tools: composer:v2
 
       - name: Cache build dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: build/
           key: build-deps-php${{ env.COMPILE_PHP_VERSION }}-${{ runner.os }}-${{ runner.arch }}
@@ -44,7 +46,7 @@ jobs:
           echo "dir=$dir" >> $env:GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**\\composer.lock') }}
@@ -100,13 +102,13 @@ jobs:
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.BINARY_NAME }}
           path: build/bin/${{ env.BINARY_NAME }}
 
       - if: ${{ github.event_name != 'workflow_dispatch' }}
         name: Upload binary to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.1
         with:
           files: build/bin/${{ env.BINARY_NAME }}

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,19 +1,26 @@
 name: Linting
+
 on:
   workflow_dispatch:
   pull_request: ~
   push:
-    branches-ignore:
-      - 'dependabot/npm_and_yarn/*'
+    branches:
+      - main
+
+permissions:
+  contents: read
+
 jobs:
   pint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: "8.4"
           tools: composer:v2
@@ -23,7 +30,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -32,5 +39,5 @@ jobs:
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
-      - name: Launch Pint inspection
-        run: composer pint
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -19,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2
@@ -36,7 +39,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,27 +4,30 @@ on:
   release:
     types: [released]
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.release.target_commitish }}
+          # Credentials must persist so git-auto-commit-action can push the CHANGELOG update.
+          persist-credentials: true
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1.12.0
         with:
           latest-version: ${{ github.event.release.tag_name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
         with:
           branch: ${{ github.event.release.target_commitish }}
           commit_message: 'chore: update changelog for ${{ github.event.release.tag_name }}'

--- a/src/Analyzers/AnalyzerInterface.php
+++ b/src/Analyzers/AnalyzerInterface.php
@@ -14,7 +14,7 @@ interface AnalyzerInterface
     /**
      * Extract package versions from lock file content array.
      *
-     * @param array $lockContent Lock file content as an associative array
+     * @param  array  $lockContent  Lock file content as an associative array
      * @return array<string, string> Package name => version map
      */
     public function extractPackageVersions(array $lockContent): array;
@@ -22,8 +22,8 @@ interface AnalyzerInterface
     /**
      * Calculate the difference between two lock file versions.
      *
-     * @param string $lastLockContent Current/latest lock file content (JSON)
-     * @param string|null $previousLockContent Previous lock file content (JSON), null if no previous version
+     * @param  string  $lastLockContent  Current/latest lock file content (JSON)
+     * @param  string|null  $previousLockContent  Previous lock file content (JSON), null if no previous version
      * @return array Array of package changes with name, from, to versions, and optional metadata
      */
     public function calculateDiff(string $lastLockContent, ?string $previousLockContent): array;
@@ -31,10 +31,10 @@ interface AnalyzerInterface
     /**
      * Get the number of releases between two versions.
      *
-     * @param string $package Package name
-     * @param string $from Starting version
-     * @param string $to Ending version
-     * @param array<string, mixed> $context Additional context (e.g., registry URL)
+     * @param  string  $package  Package name
+     * @param  string  $from  Starting version
+     * @param  string  $to  Ending version
+     * @param  array<string, mixed>  $context  Additional context (e.g., registry URL)
      * @return int|null Number of releases, or null on error
      */
     public function getReleasesCount(string $package, string $from, string $to, array $context = []): ?int;

--- a/src/Analyzers/BaseAnalyzer.php
+++ b/src/Analyzers/BaseAnalyzer.php
@@ -20,13 +20,12 @@ abstract class BaseAnalyzer implements AnalyzerInterface
 {
     public function __construct(
         protected readonly RegistryInterface $registry
-    ) {
-    }
+    ) {}
 
     /**
      * Extract package versions from lock file content array.
      *
-     * @param array $lockContent Lock file content as an associative array
+     * @param  array  $lockContent  Lock file content as an associative array
      * @return array<string, string> Package name => version map
      */
     public function extractPackageVersions(array $lockContent): array
@@ -41,8 +40,8 @@ abstract class BaseAnalyzer implements AnalyzerInterface
     /**
      * Calculate the difference between two lock file versions.
      *
-     * @param string $lastLockContent Current/latest lock file content (JSON)
-     * @param string|null $previousLockContent Previous lock file content (JSON), null if no previous version
+     * @param  string  $lastLockContent  Current/latest lock file content (JSON)
+     * @param  string|null  $previousLockContent  Previous lock file content (JSON), null if no previous version
      * @return array Array of package changes with name, from, to versions, and optional metadata
      */
     public function calculateDiff(string $lastLockContent, ?string $previousLockContent): array
@@ -96,10 +95,10 @@ abstract class BaseAnalyzer implements AnalyzerInterface
     /**
      * Get the number of releases between two versions.
      *
-     * @param string $package Package name
-     * @param string $from Starting version
-     * @param string $to Ending version
-     * @param array<string, mixed> $context Additional context (e.g., registry URL)
+     * @param  string  $package  Package name
+     * @param  string  $from  Starting version
+     * @param  string  $to  Ending version
+     * @param  array<string, mixed>  $context  Additional context (e.g., registry URL)
      * @return int|null Number of releases, or null on error
      */
     public function getReleasesCount(string $package, string $from, string $to, array $context = []): ?int
@@ -118,10 +117,10 @@ abstract class BaseAnalyzer implements AnalyzerInterface
      *
      * An advisory is "fixed" if the from-version is affected but the to-version is not.
      *
-     * @param string $package Package name
-     * @param string $from Starting version
-     * @param string $to Ending version
-     * @param array<string, mixed> $context Additional context
+     * @param  string  $package  Package name
+     * @param  string  $from  Starting version
+     * @param  string  $to  Ending version
+     * @param  array<string, mixed>  $context  Additional context
      * @return array<SecurityAdvisory>
      */
     public function getFixedAdvisories(string $package, string $from, string $to, array $context = []): array
@@ -152,7 +151,7 @@ abstract class BaseAnalyzer implements AnalyzerInterface
                 continue;
             }
 
-            if ($fromAffected && !$toAffected) {
+            if ($fromAffected && ! $toAffected) {
                 $fixed[] = $advisory;
             }
         }
@@ -173,7 +172,7 @@ abstract class BaseAnalyzer implements AnalyzerInterface
      *
      * Subclasses must implement this to return their specific lock file parser.
      *
-     * @param string $content Lock file content (JSON)
+     * @param  string  $content  Lock file content (JSON)
      * @return LockFileInterface Lock file parser instance
      */
     abstract protected function createLockFileParser(string $content): LockFileInterface;
@@ -184,9 +183,9 @@ abstract class BaseAnalyzer implements AnalyzerInterface
      * Allows subclasses to add custom fields (e.g., infos_url for private repos).
      * Default implementation returns an empty array.
      *
-     * @param string $packageName Package name
-     * @param array $lastLockArray Current lock file as array
-     * @param array $previousLockArray Previous lock file as array
+     * @param  string  $packageName  Package name
+     * @param  array  $lastLockArray  Current lock file as array
+     * @param  array  $previousLockArray  Previous lock file as array
      * @return array<string, mixed> Additional fields to merge into package diff
      */
     protected function getAdditionalPackageFields(string $packageName, array $lastLockArray, array $previousLockArray): array

--- a/src/Analyzers/ComposerAnalyzer.php
+++ b/src/Analyzers/ComposerAnalyzer.php
@@ -50,8 +50,8 @@ class ComposerAnalyzer extends BaseAnalyzer
     /**
      * Get the package information URL, detecting private repositories.
      *
-     * @param string $name Package name
-     * @param array $composerLock Composer lock file content as array
+     * @param  string  $name  Package name
+     * @param  array  $composerLock  Composer lock file content as array
      * @return string Package information URL
      */
     private function getPackageUrl(string $name, array $composerLock): string
@@ -63,7 +63,7 @@ class ComposerAnalyzer extends BaseAnalyzer
             ->merge($composerLock['packages-dev'] ?? [])
             ->first(fn ($package) => $package['name'] === $name);
 
-        if (!$packageInfo) {
+        if (! $packageInfo) {
             return $url;
         }
 
@@ -82,10 +82,10 @@ class ComposerAnalyzer extends BaseAnalyzer
      *
      * Accepts URL as array context for compatibility with BaseAnalyzer.
      *
-     * @param string $package Package name
-     * @param string $from Starting version
-     * @param string $to Ending version
-     * @param array $context Context array containing 'url' key for private repos
+     * @param  string  $package  Package name
+     * @param  string  $from  Starting version
+     * @param  string  $to  Ending version
+     * @param  array  $context  Context array containing 'url' key for private repos
      * @return int|null Number of releases, or null on error
      */
     public function getReleasesCount(string $package, string $from, string $to, array $context = []): ?int
@@ -96,10 +96,10 @@ class ComposerAnalyzer extends BaseAnalyzer
     /**
      * Convenience method for getting release count with URL string.
      *
-     * @param string $package Package name
-     * @param string $from Starting version
-     * @param string $to Ending version
-     * @param string $url Package information URL (for private repos)
+     * @param  string  $package  Package name
+     * @param  string  $from  Starting version
+     * @param  string  $to  Ending version
+     * @param  string  $url  Package information URL (for private repos)
      * @return int|null Number of releases, or null on error
      */
     public function getReleasesCountWithUrl(string $package, string $from, string $to, string $url): ?int

--- a/src/Analyzers/Exceptions/PackageInformationsException.php
+++ b/src/Analyzers/Exceptions/PackageInformationsException.php
@@ -7,6 +7,4 @@ namespace Whatsdiff\Analyzers\Exceptions;
 use Exception;
 use Throwable;
 
-class PackageInformationsException extends Exception implements Throwable
-{
-}
+class PackageInformationsException extends Exception implements Throwable {}

--- a/src/Analyzers/LockFile/ComposerLockFile.php
+++ b/src/Analyzers/LockFile/ComposerLockFile.php
@@ -16,12 +16,13 @@ use Illuminate\Support\Collection;
 class ComposerLockFile implements LockFileInterface
 {
     private array $lockData;
+
     private Collection $packages;
 
     /**
      * Create a new parser and parse the lock file content.
      *
-     * @param string $lockFileContent Raw composer.lock content (JSON)
+     * @param  string  $lockFileContent  Raw composer.lock content (JSON)
      */
     public function __construct(string $lockFileContent)
     {
@@ -42,7 +43,7 @@ class ComposerLockFile implements LockFileInterface
     /**
      * Get version for a specific package.
      *
-     * @param string $package Package name
+     * @param  string  $package  Package name
      * @return string|null Version or null if package not found
      */
     public function getVersion(string $package): ?string
@@ -53,7 +54,7 @@ class ComposerLockFile implements LockFileInterface
     /**
      * Get repository URL for a specific package.
      *
-     * @param string $package Package name
+     * @param  string  $package  Package name
      * @return string|null Repository URL or null if not found
      */
     public function getRepositoryUrl(string $package): ?string

--- a/src/Analyzers/LockFile/LockFileInterface.php
+++ b/src/Analyzers/LockFile/LockFileInterface.php
@@ -24,7 +24,7 @@ interface LockFileInterface
      * Create a new parser with lock file content.
      * The parser will parse and store the data internally.
      *
-     * @param string $lockFileContent Raw lock file content (JSON)
+     * @param  string  $lockFileContent  Raw lock file content (JSON)
      */
     public function __construct(string $lockFileContent);
 
@@ -38,7 +38,7 @@ interface LockFileInterface
     /**
      * Get version for a specific package.
      *
-     * @param string $package Package name
+     * @param  string  $package  Package name
      * @return string|null Version or null if package not found
      */
     public function getVersion(string $package): ?string;
@@ -46,7 +46,7 @@ interface LockFileInterface
     /**
      * Get repository URL for a specific package.
      *
-     * @param string $package Package name
+     * @param  string  $package  Package name
      * @return string|null Repository URL or null if not found
      */
     public function getRepositoryUrl(string $package): ?string;

--- a/src/Analyzers/LockFile/NpmPackageLockFile.php
+++ b/src/Analyzers/LockFile/NpmPackageLockFile.php
@@ -16,12 +16,13 @@ use Illuminate\Support\Collection;
 class NpmPackageLockFile implements LockFileInterface
 {
     private array $lockData;
+
     private Collection $packages;
 
     /**
      * Create a new parser and parse the lock file content.
      *
-     * @param string $lockFileContent Raw package-lock.json content (JSON)
+     * @param  string  $lockFileContent  Raw package-lock.json content (JSON)
      */
     public function __construct(string $lockFileContent)
     {
@@ -42,7 +43,7 @@ class NpmPackageLockFile implements LockFileInterface
     /**
      * Get version for a specific package.
      *
-     * @param string $package Package name
+     * @param  string  $package  Package name
      * @return string|null Version or null if package not found
      */
     public function getVersion(string $package): ?string
@@ -53,7 +54,7 @@ class NpmPackageLockFile implements LockFileInterface
     /**
      * Get repository URL for a specific package.
      *
-     * @param string $package Package name
+     * @param  string  $package  Package name
      * @return string|null Repository URL or null if not found
      */
     public function getRepositoryUrl(string $package): ?string
@@ -79,7 +80,7 @@ class NpmPackageLockFile implements LockFileInterface
     private function parsePackages(): Collection
     {
         $packages = collect($this->lockData['packages'] ?? [])
-            ->filter(fn ($package, $key) => !empty($key) && !empty($package['version']));
+            ->filter(fn ($package, $key) => ! empty($key) && ! empty($package['version']));
 
         return $packages->mapWithKeys(function ($package, $key) {
             $packageName = str_replace('node_modules/', '', $key);
@@ -94,6 +95,6 @@ class NpmPackageLockFile implements LockFileInterface
             }
 
             return [$packageName => $data];
-        })->filter(fn ($data, $name) => !empty($name));
+        })->filter(fn ($data, $name) => ! empty($name));
     }
 }

--- a/src/Analyzers/PackageManagerType.php
+++ b/src/Analyzers/PackageManagerType.php
@@ -29,7 +29,7 @@ enum PackageManagerType: string
     {
         return match ($this) {
             self::COMPOSER => $package ? "https://repo.packagist.org/p2/{$package}.json" : 'https://repo.packagist.org',
-            self::NPM => $package ? "https://registry.npmjs.org/" . urlencode($package) : 'https://registry.npmjs.org',
+            self::NPM => $package ? 'https://registry.npmjs.org/'.urlencode($package) : 'https://registry.npmjs.org',
         };
     }
 
@@ -37,5 +37,4 @@ enum PackageManagerType: string
     {
         return array_map(fn (self $type) => $type->getLockFileName(), self::cases());
     }
-
 }

--- a/src/Analyzers/Registries/NpmRegistry.php
+++ b/src/Analyzers/Registries/NpmRegistry.php
@@ -28,10 +28,11 @@ class NpmRegistry implements RegistryInterface
     /**
      * Get complete package metadata from npm registry.
      *
-     * @param string $package Package name
-     * @param array<string, mixed> $options Options may include:
-     *   - 'url': Custom registry URL (for private registries)
+     * @param  string  $package  Package name
+     * @param  array<string, mixed>  $options  Options may include:
+     *                                         - 'url': Custom registry URL (for private registries)
      * @return array<string, mixed> Package metadata
+     *
      * @throws PackageInformationsException If package cannot be fetched
      */
     public function getPackageMetadata(string $package, array $options = []): array
@@ -42,7 +43,7 @@ class NpmRegistry implements RegistryInterface
             $response = $this->httpService->get($url);
         } catch (\Exception $e) {
             throw new PackageInformationsException(
-                "Failed to fetch package information for {$package}: " . $e->getMessage()
+                "Failed to fetch package information for {$package}: ".$e->getMessage()
             );
         }
 
@@ -60,18 +61,19 @@ class NpmRegistry implements RegistryInterface
     /**
      * Get versions of a package between two version constraints.
      *
-     * @param string $package Package name
-     * @param string $from Starting version (exclusive)
-     * @param string $to Ending version (inclusive)
-     * @param array<string, mixed> $options Options (see getPackageMetadata)
+     * @param  string  $package  Package name
+     * @param  string  $from  Starting version (exclusive)
+     * @param  string  $to  Ending version (inclusive)
+     * @param  array<string, mixed>  $options  Options (see getPackageMetadata)
      * @return array<int, string> Array of version strings
+     *
      * @throws PackageInformationsException If package cannot be fetched
      */
     public function getVersions(string $package, string $from, string $to, array $options = []): array
     {
         $packageData = $this->getPackageMetadata($package, $options);
 
-        if (!isset($packageData['versions'])) {
+        if (! isset($packageData['versions'])) {
             return [];
         }
 
@@ -92,8 +94,8 @@ class NpmRegistry implements RegistryInterface
     /**
      * Get repository URL for a package from npm registry.
      *
-     * @param string $package Package name
-     * @param array<string, mixed> $options Options (see getPackageMetadata)
+     * @param  string  $package  Package name
+     * @param  array<string, mixed>  $options  Options (see getPackageMetadata)
      * @return string|null Repository URL or null if not available
      */
     public function getRepositoryUrl(string $package, array $options = []): ?string
@@ -121,8 +123,8 @@ class NpmRegistry implements RegistryInterface
      *
      * Uses the GitHub Advisory Database API for npm ecosystem advisories.
      *
-     * @param array<string> $packages Package names
-     * @param array<string, mixed> $options Additional options
+     * @param  array<string>  $packages  Package names
+     * @param  array<string, mixed>  $options  Additional options
      * @return array<string, array<SecurityAdvisory>> Advisories indexed by package name
      */
     public function getSecurityAdvisories(array $packages, array $options = []): array
@@ -130,7 +132,7 @@ class NpmRegistry implements RegistryInterface
         $result = [];
 
         foreach ($packages as $package) {
-            $url = 'https://api.github.com/advisories?affects=' . urlencode($package) . '&ecosystem=npm';
+            $url = 'https://api.github.com/advisories?affects='.urlencode($package).'&ecosystem=npm';
 
             try {
                 $response = $this->httpService->get($url);
@@ -140,7 +142,7 @@ class NpmRegistry implements RegistryInterface
 
             $advisories = json_decode($response, true);
 
-            if (!is_array($advisories)) {
+            if (! is_array($advisories)) {
                 continue;
             }
 
@@ -178,7 +180,7 @@ class NpmRegistry implements RegistryInterface
      * - "git://github.com/user/repo.git"
      * - "https://github.com/user/repo"
      *
-     * @param string $url Repository URL from npm
+     * @param  string  $url  Repository URL from npm
      * @return string Normalized HTTPS URL
      */
     private function normalizeRepositoryUrl(string $url): string

--- a/src/Analyzers/Registries/PackagistRegistry.php
+++ b/src/Analyzers/Registries/PackagistRegistry.php
@@ -28,11 +28,12 @@ class PackagistRegistry implements RegistryInterface
     /**
      * Get complete package metadata from Packagist.
      *
-     * @param string $package Package name
-     * @param array<string, mixed> $options Options may include:
-     *   - 'url': Custom registry URL (for private repositories)
-     *   - 'auth': Array with 'username' and 'password' for http-basic auth
+     * @param  string  $package  Package name
+     * @param  array<string, mixed>  $options  Options may include:
+     *                                         - 'url': Custom registry URL (for private repositories)
+     *                                         - 'auth': Array with 'username' and 'password' for http-basic auth
      * @return array<string, mixed> Package metadata
+     *
      * @throws PackageInformationsException If package cannot be fetched
      */
     public function getPackageMetadata(string $package, array $options = []): array
@@ -46,7 +47,7 @@ class PackagistRegistry implements RegistryInterface
             $httpOptions = $authOptions['options'];
 
             // Load auth from auth.json if not explicitly provided
-            if (!isset($options['auth']) && empty($httpOptions['auth'])) {
+            if (! isset($options['auth']) && empty($httpOptions['auth'])) {
                 $authJson = $this->loadAuthJson();
                 $domain = parse_url($cleanUrl, PHP_URL_HOST);
 
@@ -63,7 +64,7 @@ class PackagistRegistry implements RegistryInterface
             $response = $this->httpService->get($cleanUrl, $httpOptions);
         } catch (\Exception $e) {
             throw new PackageInformationsException(
-                "Failed to fetch package information for {$package}: " . $e->getMessage()
+                "Failed to fetch package information for {$package}: ".$e->getMessage()
             );
         }
 
@@ -81,18 +82,19 @@ class PackagistRegistry implements RegistryInterface
     /**
      * Get versions of a package between two version constraints.
      *
-     * @param string $package Package name
-     * @param string $from Starting version (exclusive)
-     * @param string $to Ending version (inclusive)
-     * @param array<string, mixed> $options Options (see getPackageMetadata)
+     * @param  string  $package  Package name
+     * @param  string  $from  Starting version (exclusive)
+     * @param  string  $to  Ending version (inclusive)
+     * @param  array<string, mixed>  $options  Options (see getPackageMetadata)
      * @return array<int, string> Array of version strings
+     *
      * @throws PackageInformationsException If package cannot be fetched
      */
     public function getVersions(string $package, string $from, string $to, array $options = []): array
     {
         $packageData = $this->getPackageMetadata($package, $options);
 
-        if (!isset($packageData['packages'][$package])) {
+        if (! isset($packageData['packages'][$package])) {
             return [];
         }
 
@@ -113,8 +115,8 @@ class PackagistRegistry implements RegistryInterface
     /**
      * Get repository URL for a package from Packagist.
      *
-     * @param string $package Package name
-     * @param array<string, mixed> $options Options (see getPackageMetadata)
+     * @param  string  $package  Package name
+     * @param  array<string, mixed>  $options  Options (see getPackageMetadata)
      * @return string|null Repository URL or null if not available
      */
     public function getRepositoryUrl(string $package, array $options = []): ?string
@@ -125,7 +127,7 @@ class PackagistRegistry implements RegistryInterface
             return null;
         }
 
-        if (!isset($packageData['packages'][$package])) {
+        if (! isset($packageData['packages'][$package])) {
             return null;
         }
 
@@ -161,8 +163,8 @@ class PackagistRegistry implements RegistryInterface
      *
      * Uses the Packagist Security Advisories API which supports batch queries.
      *
-     * @param array<string> $packages Package names
-     * @param array<string, mixed> $options Additional options
+     * @param  array<string>  $packages  Package names
+     * @param  array<string, mixed>  $options  Additional options
      * @return array<string, array<SecurityAdvisory>> Advisories indexed by package name
      */
     public function getSecurityAdvisories(array $packages, array $options = []): array
@@ -172,11 +174,11 @@ class PackagistRegistry implements RegistryInterface
         }
 
         $queryParams = implode('&', array_map(
-            fn (string $pkg) => 'packages[]=' . urlencode($pkg),
+            fn (string $pkg) => 'packages[]='.urlencode($pkg),
             $packages
         ));
 
-        $url = 'https://packagist.org/api/security-advisories/?' . $queryParams;
+        $url = 'https://packagist.org/api/security-advisories/?'.$queryParams;
 
         try {
             $response = $this->httpService->get($url);
@@ -186,7 +188,7 @@ class PackagistRegistry implements RegistryInterface
 
         $data = json_decode($response, true);
 
-        if ($data === null || !isset($data['advisories'])) {
+        if ($data === null || ! isset($data['advisories'])) {
             return [];
         }
 
@@ -217,7 +219,7 @@ class PackagistRegistry implements RegistryInterface
      * - https://api.github.com/repos/owner/repo/zipball/ref -> https://github.com/owner/repo
      * - https://api.github.com/repos/owner/repo/tarball/ref -> https://github.com/owner/repo
      *
-     * @param string $url URL to normalize
+     * @param  string  $url  URL to normalize
      * @return string Clean repository URL
      */
     private function normalizeRepositoryUrl(string $url): string
@@ -246,7 +248,7 @@ class PackagistRegistry implements RegistryInterface
     /**
      * Extract repository URL from GitHub issues URL.
      *
-     * @param string|null $issuesUrl Issues URL (e.g., https://github.com/owner/repo/issues)
+     * @param  string|null  $issuesUrl  Issues URL (e.g., https://github.com/owner/repo/issues)
      * @return string|null Repository URL or null
      */
     private function extractRepoFromIssuesUrl(?string $issuesUrl): ?string
@@ -267,7 +269,7 @@ class PackagistRegistry implements RegistryInterface
     /**
      * Extract authentication credentials from URL.
      *
-     * @param string $url URL that may contain credentials
+     * @param  string  $url  URL that may contain credentials
      * @return array{url: string, options: array<string, mixed>} Clean URL and extracted options
      */
     private function extractAuthFromUrl(string $url): array
@@ -282,17 +284,17 @@ class PackagistRegistry implements RegistryInterface
             ];
 
             // Rebuild URL without auth
-            $cleanUrl = $parsedUrl['scheme'] . '://';
+            $cleanUrl = $parsedUrl['scheme'].'://';
             $cleanUrl .= $parsedUrl['host'];
             if (isset($parsedUrl['port'])) {
-                $cleanUrl .= ':' . $parsedUrl['port'];
+                $cleanUrl .= ':'.$parsedUrl['port'];
             }
             $cleanUrl .= $parsedUrl['path'] ?? '';
             if (isset($parsedUrl['query'])) {
-                $cleanUrl .= '?' . $parsedUrl['query'];
+                $cleanUrl .= '?'.$parsedUrl['query'];
             }
             if (isset($parsedUrl['fragment'])) {
-                $cleanUrl .= '#' . $parsedUrl['fragment'];
+                $cleanUrl .= '#'.$parsedUrl['fragment'];
             }
 
             return ['url' => $cleanUrl, 'options' => $options];
@@ -311,10 +313,10 @@ class PackagistRegistry implements RegistryInterface
     private function loadAuthJson(): array
     {
         $currentDir = getcwd() ?: '';
-        $localAuthPath = $currentDir . DIRECTORY_SEPARATOR . 'auth.json';
+        $localAuthPath = $currentDir.DIRECTORY_SEPARATOR.'auth.json';
 
         $HOME = getenv('HOME') ?: getenv('USERPROFILE');
-        $globalAuthPath = $HOME . DIRECTORY_SEPARATOR . '.composer/auth.json';
+        $globalAuthPath = $HOME.DIRECTORY_SEPARATOR.'.composer/auth.json';
 
         $localAuth = [];
         $globalAuth = [];

--- a/src/Analyzers/Registries/RegistryInterface.php
+++ b/src/Analyzers/Registries/RegistryInterface.php
@@ -18,9 +18,10 @@ interface RegistryInterface
     /**
      * Get complete package metadata from the registry.
      *
-     * @param string $package Package name
-     * @param array<string, mixed> $options Additional options (e.g., auth credentials, registry URL)
+     * @param  string  $package  Package name
+     * @param  array<string, mixed>  $options  Additional options (e.g., auth credentials, registry URL)
      * @return array<string, mixed> Package metadata
+     *
      * @throws \Whatsdiff\Analyzers\Exceptions\PackageInformationsException If package cannot be fetched
      */
     public function getPackageMetadata(string $package, array $options = []): array;
@@ -28,11 +29,12 @@ interface RegistryInterface
     /**
      * Get versions of a package between two version constraints.
      *
-     * @param string $package Package name
-     * @param string $from Starting version (exclusive)
-     * @param string $to Ending version (inclusive)
-     * @param array<string, mixed> $options Additional options (e.g., auth credentials, registry URL)
+     * @param  string  $package  Package name
+     * @param  string  $from  Starting version (exclusive)
+     * @param  string  $to  Ending version (inclusive)
+     * @param  array<string, mixed>  $options  Additional options (e.g., auth credentials, registry URL)
      * @return array<int, string> Array of version strings
+     *
      * @throws \Whatsdiff\Analyzers\Exceptions\PackageInformationsException If package cannot be fetched
      */
     public function getVersions(string $package, string $from, string $to, array $options = []): array;
@@ -40,8 +42,8 @@ interface RegistryInterface
     /**
      * Get repository URL for a package.
      *
-     * @param string $package Package name
-     * @param array<string, mixed> $options Additional options (e.g., auth credentials)
+     * @param  string  $package  Package name
+     * @param  array<string, mixed>  $options  Additional options (e.g., auth credentials)
      * @return string|null Repository URL or null if not available
      */
     public function getRepositoryUrl(string $package, array $options = []): ?string;
@@ -49,8 +51,8 @@ interface RegistryInterface
     /**
      * Get security advisories for one or more packages.
      *
-     * @param array<string> $packages Package names
-     * @param array<string, mixed> $options Additional options
+     * @param  array<string>  $packages  Package names
+     * @param  array<string, mixed>  $options  Additional options
      * @return array<string, array<\Whatsdiff\Data\SecurityAdvisory>> Advisories indexed by package name
      */
     public function getSecurityAdvisories(array $packages, array $options = []): array;

--- a/src/Analyzers/ReleaseNotes/ChangelogParser.php
+++ b/src/Analyzers/ReleaseNotes/ChangelogParser.php
@@ -21,16 +21,15 @@ use Whatsdiff\Helpers\VersionNormalizer;
  */
 class ChangelogParser
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
+
     /**
      * Parse changelog content and extract releases within version range.
      *
-     * @param string $content Changelog markdown content
-     * @param string $fromVersion Starting version (exclusive)
-     * @param string $toVersion Ending version (inclusive)
-     * @param bool $includePrerelease Whether to include pre-release versions
+     * @param  string  $content  Changelog markdown content
+     * @param  string  $fromVersion  Starting version (exclusive)
+     * @param  string  $toVersion  Ending version (inclusive)
+     * @param  bool  $includePrerelease  Whether to include pre-release versions
      * @return ReleaseNotesCollection Collection of release notes
      */
     public function parse(
@@ -71,6 +70,7 @@ class ChangelogParser
                 $currentVersion = $versionData['version'];
                 $currentDate = $versionData['date'];
                 $currentContent = [];
+
                 continue;
             }
 
@@ -147,8 +147,8 @@ class ChangelogParser
 
         // Parse date
         $date = $dateString !== null
-            ? DateTimeImmutable::createFromFormat('Y-m-d', $dateString) ?: new DateTimeImmutable()
-            : new DateTimeImmutable();
+            ? DateTimeImmutable::createFromFormat('Y-m-d', $dateString) ?: new DateTimeImmutable
+            : new DateTimeImmutable;
 
         return new ReleaseNote(
             tagName: $version,
@@ -174,7 +174,7 @@ class ChangelogParser
         $normalizedVersion = VersionNormalizer::normalize($version);
 
         // Skip pre-release versions if not included
-        if (!$includePrerelease && $this->isPrerelease($normalizedVersion)) {
+        if (! $includePrerelease && $this->isPrerelease($normalizedVersion)) {
             return false;
         }
 
@@ -198,6 +198,7 @@ class ChangelogParser
     private function isPrerelease(string $version): bool
     {
         $stability = VersionParser::parseStability($version);
+
         return in_array($stability, ['alpha', 'beta', 'RC', 'dev'], true);
     }
 }

--- a/src/Analyzers/ReleaseNotes/Fetchers/GithubChangelogFetcher.php
+++ b/src/Analyzers/ReleaseNotes/Fetchers/GithubChangelogFetcher.php
@@ -32,12 +32,10 @@ class GithubChangelogFetcher implements ReleaseNotesFetcherInterface
         // 'NEWS',
     ];
 
-
     public function __construct(
         private readonly HttpService $httpService,
         private readonly ChangelogParser $parser
-    ) {
-    }
+    ) {}
 
     public function fetch(
         string $package,
@@ -120,5 +118,4 @@ class GithubChangelogFetcher implements ReleaseNotesFetcherInterface
 
         return null;
     }
-
 }

--- a/src/Analyzers/ReleaseNotes/Fetchers/GithubReleaseFetcher.php
+++ b/src/Analyzers/ReleaseNotes/Fetchers/GithubReleaseFetcher.php
@@ -10,8 +10,8 @@ use Whatsdiff\Analyzers\PackageManagerType;
 use Whatsdiff\Analyzers\ReleaseNotes\ReleaseNotesFetcherInterface;
 use Whatsdiff\Data\ReleaseNote;
 use Whatsdiff\Data\ReleaseNotesCollection;
-use Whatsdiff\Services\HttpService;
 use Whatsdiff\Helpers\VersionNormalizer;
+use Whatsdiff\Services\HttpService;
 
 /**
  * Fetches release notes from GitHub Releases API.
@@ -22,8 +22,7 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
 
     public function __construct(
         private HttpService $httpService
-    ) {
-    }
+    ) {}
 
     public function fetch(
         string $package,
@@ -70,9 +69,9 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
      * Fetch all releases from GitHub API, handling pagination.
      * Stops fetching when we've gone past the fromVersion (optimization).
      *
-     * @param string $owner Repository owner
-     * @param string $repo Repository name
-     * @param string $fromVersion Starting version (to optimize pagination)
+     * @param  string  $owner  Repository owner
+     * @param  string  $repo  Repository name
+     * @param  string  $fromVersion  Starting version (to optimize pagination)
      * @return array<int, mixed> All releases from the API
      */
     private function fetchAllReleases(string $owner, string $repo, string $fromVersion): array
@@ -83,7 +82,7 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
         $normalizedFrom = VersionNormalizer::normalize($fromVersion);
 
         while (true) {
-            $apiUrl = self::GITHUB_API_URL . "/repos/{$owner}/{$repo}/releases?per_page={$perPage}&page={$page}";
+            $apiUrl = self::GITHUB_API_URL."/repos/{$owner}/{$repo}/releases?per_page={$perPage}&page={$page}";
             $responseData = $this->httpService->getWithHeaders($apiUrl, [
                 'headers' => [
                     'Accept' => 'application/vnd.github+json',
@@ -92,7 +91,7 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
 
             $releases = json_decode($responseData['body'], true);
 
-            if (!is_array($releases) || empty($releases)) {
+            if (! is_array($releases) || empty($releases)) {
                 // No more releases
                 break;
             }
@@ -117,7 +116,7 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
                     $releaseMajor = (int) explode('.', $version)[0];
 
                     // Only use same-major-version releases for the stop decision
-                    if ($releaseMajor === $fromMajor && !Comparator::greaterThan($version, $normalizedFrom)) {
+                    if ($releaseMajor === $fromMajor && ! Comparator::greaterThan($version, $normalizedFrom)) {
                         $foundStopCondition = true;
                         break;
                     }
@@ -134,6 +133,7 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
             // If we got a full page, there might be more releases on the next page
             if (count($releases) === $perPage) {
                 $page++;
+
                 continue;
             }
 
@@ -163,10 +163,10 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
     /**
      * Build ReleaseNotesCollection from GitHub API response.
      *
-     * @param array<int, mixed> $releases GitHub releases data
-     * @param string $fromVersion Starting version (exclusive)
-     * @param string $toVersion Ending version (inclusive)
-     * @param bool $includePrerelease Whether to include pre-release versions
+     * @param  array<int, mixed>  $releases  GitHub releases data
+     * @param  string  $fromVersion  Starting version (exclusive)
+     * @param  string  $toVersion  Ending version (inclusive)
+     * @param  bool  $includePrerelease  Whether to include pre-release versions
      */
     private function buildReleaseNotesCollection(
         array $releases,
@@ -183,7 +183,7 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
             }
 
             // Skip pre-releases if not included
-            if (!$includePrerelease && ($release['prerelease'] ?? false)) {
+            if (! $includePrerelease && ($release['prerelease'] ?? false)) {
                 continue;
             }
 
@@ -196,13 +196,13 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
             $version = VersionNormalizer::normalize($tagName);
 
             // Filter by version range: fromVersion < version <= toVersion
-            if (!$this->isVersionInRange($version, $fromVersion, $toVersion)) {
+            if (! $this->isVersionInRange($version, $fromVersion, $toVersion)) {
                 continue;
             }
 
             // Parse the date
             $publishedAt = $release['published_at'] ?? $release['created_at'] ?? null;
-            $date = $publishedAt ? new DateTimeImmutable($publishedAt) : new DateTimeImmutable();
+            $date = $publishedAt ? new DateTimeImmutable($publishedAt) : new DateTimeImmutable;
 
             $releaseNotes[] = new ReleaseNote(
                 tagName: $tagName,

--- a/src/Analyzers/ReleaseNotes/Fetchers/LocalVendorChangelogFetcher.php
+++ b/src/Analyzers/ReleaseNotes/Fetchers/LocalVendorChangelogFetcher.php
@@ -34,8 +34,7 @@ class LocalVendorChangelogFetcher implements ReleaseNotesFetcherInterface
 
     public function __construct(
         private readonly ChangelogParser $parser
-    ) {
-    }
+    ) {}
 
     public function fetch(
         string $package,

--- a/src/Analyzers/ReleaseNotes/ReleaseNotesFetcherInterface.php
+++ b/src/Analyzers/ReleaseNotes/ReleaseNotesFetcherInterface.php
@@ -12,13 +12,13 @@ interface ReleaseNotesFetcherInterface
     /**
      * Fetch release notes for a package between two versions.
      *
-     * @param string $package Package name (e.g., "symfony/console")
-     * @param string $fromVersion Starting version (exclusive)
-     * @param string $toVersion Ending version (inclusive)
-     * @param string $repositoryUrl Repository URL (e.g., "https://github.com/symfony/console")
-     * @param PackageManagerType $packageManagerType Package manager type (COMPOSER or NPM)
-     * @param string|null $localPath Local filesystem path to package (vendor/package or node_modules/package)
-     * @param bool $includePrerelease Whether to include pre-release versions
+     * @param  string  $package  Package name (e.g., "symfony/console")
+     * @param  string  $fromVersion  Starting version (exclusive)
+     * @param  string  $toVersion  Ending version (inclusive)
+     * @param  string  $repositoryUrl  Repository URL (e.g., "https://github.com/symfony/console")
+     * @param  PackageManagerType  $packageManagerType  Package manager type (COMPOSER or NPM)
+     * @param  string|null  $localPath  Local filesystem path to package (vendor/package or node_modules/package)
+     * @param  bool  $includePrerelease  Whether to include pre-release versions
      * @return ReleaseNotesCollection|null Release notes collection or null if fetch fails
      */
     public function fetch(
@@ -34,8 +34,8 @@ interface ReleaseNotesFetcherInterface
     /**
      * Check if this fetcher supports the given source.
      *
-     * @param string $repositoryUrl Repository URL
-     * @param string|null $localPath Local filesystem path to package
+     * @param  string  $repositoryUrl  Repository URL
+     * @param  string|null  $localPath  Local filesystem path to package
      * @return bool True if this fetcher can handle the source
      */
     public function supports(string $repositoryUrl, ?string $localPath): bool;

--- a/src/Analyzers/ReleaseNotes/ReleaseNotesResolver.php
+++ b/src/Analyzers/ReleaseNotes/ReleaseNotesResolver.php
@@ -32,13 +32,13 @@ class ReleaseNotesResolver
     /**
      * Resolve release notes by trying each fetcher in sequence.
      *
-     * @param string $package Package name (e.g., "symfony/console")
-     * @param string $fromVersion Starting version (exclusive)
-     * @param string $toVersion Ending version (inclusive)
-     * @param string $repositoryUrl Repository URL (e.g., "https://github.com/symfony/console")
-     * @param PackageManagerType $packageManagerType Package manager type (COMPOSER or NPM)
-     * @param string|null $localPath Local filesystem path to package (vendor/package or node_modules/package)
-     * @param bool $includePrerelease Whether to include pre-release versions
+     * @param  string  $package  Package name (e.g., "symfony/console")
+     * @param  string  $fromVersion  Starting version (exclusive)
+     * @param  string  $toVersion  Ending version (inclusive)
+     * @param  string  $repositoryUrl  Repository URL (e.g., "https://github.com/symfony/console")
+     * @param  PackageManagerType  $packageManagerType  Package manager type (COMPOSER or NPM)
+     * @param  string|null  $localPath  Local filesystem path to package (vendor/package or node_modules/package)
+     * @param  bool  $includePrerelease  Whether to include pre-release versions
      * @return ReleaseNotesCollection|null Release notes collection or null if all fetchers fail
      */
     public function resolve(
@@ -52,7 +52,7 @@ class ReleaseNotesResolver
     ): ?ReleaseNotesCollection {
         foreach ($this->fetchers as $fetcher) {
             // Check if this fetcher supports the source
-            if (!$fetcher->supports($repositoryUrl, $localPath)) {
+            if (! $fetcher->supports($repositoryUrl, $localPath)) {
                 continue;
             }
 
@@ -68,7 +68,7 @@ class ReleaseNotesResolver
             );
 
             // Return the first successful result
-            if ($result !== null && !$result->isEmpty()) {
+            if ($result !== null && ! $result->isEmpty()) {
                 return $result;
             }
         }

--- a/src/Application.php
+++ b/src/Application.php
@@ -56,7 +56,7 @@ class Application extends BaseApplication
      */
     public static function instantiateContainer(): ContainerInterface
     {
-        $container = new Container();
+        $container = new Container;
 
         // Enable autowiring via ReflectionContainer delegate (with caching for performance)
         $container->delegate(new ReflectionContainer(true));

--- a/src/Commands/AnalyseCommand.php
+++ b/src/Commands/AnalyseCommand.php
@@ -9,12 +9,12 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Whatsdiff\Analyzers\PackageManagerType;
+use Whatsdiff\Helpers\CommandErrorHandler;
 use Whatsdiff\Outputs\JsonOutput;
 use Whatsdiff\Outputs\MarkdownOutput;
 use Whatsdiff\Outputs\OutputFormatterInterface;
 use Whatsdiff\Outputs\TextOutput;
 use Whatsdiff\Services\CacheService;
-use Whatsdiff\Helpers\CommandErrorHandler;
 use Whatsdiff\Services\DiffCalculator;
 
 use function Laravel\Prompts\clear;
@@ -103,7 +103,6 @@ class AnalyseCommand extends Command
                 $this->diffCalculator->toCommit($toCommit);
             }
 
-
             if ($this->shouldShowProgress($format, $noAnsi, $input)) {
                 [$total, $generator] = $this->diffCalculator->run(withProgress: true);
 
@@ -135,8 +134,8 @@ class AnalyseCommand extends Command
     private function getFormatter(string $format, bool $noAnsi): OutputFormatterInterface
     {
         return match ($format) {
-            'json' => new JsonOutput(),
-            'markdown' => new MarkdownOutput(),
+            'json' => new JsonOutput,
+            'markdown' => new MarkdownOutput,
             default => new TextOutput(! $noAnsi),
         };
     }
@@ -152,11 +151,6 @@ class AnalyseCommand extends Command
             && ! $input->getParameterOption('--no-interaction', false);
     }
 
-    /**
-     * @param  mixed  $total
-     * @param  mixed  $generator
-     * @return void
-     */
     public function showProgressBar(mixed $total, mixed $generator): void
     {
         $startTime = microtime(true);
@@ -170,7 +164,7 @@ class AnalyseCommand extends Command
             // Check if 1 second has passed
             $elapsedTime = microtime(true) - $startTime;
 
-            if (!$progressStarted && $elapsedTime >= 1.0) {
+            if (! $progressStarted && $elapsedTime >= 1.0) {
                 // Start showing the progress bar
                 $progress = progress(label: 'Analysing changes..', steps: $total);
                 $progress->start();
@@ -203,7 +197,7 @@ class AnalyseCommand extends Command
         $allTypes = PackageManagerType::cases();
 
         // If neither include nor exclude is specified, return all types
-        if (!$includeTypes && !$excludeTypes) {
+        if (! $includeTypes && ! $excludeTypes) {
             return $allTypes;
         }
 
@@ -216,6 +210,7 @@ class AnalyseCommand extends Command
                 $type = $this->parsePackageManagerType($typeString);
                 if ($type === null) {
                     $output->writeln("<error>Invalid package manager type: '{$typeString}'. Valid types: composer, npmjs</error>");
+
                     return null;
                 }
                 $parsedTypes[] = $type;
@@ -232,13 +227,14 @@ class AnalyseCommand extends Command
             $type = $this->parsePackageManagerType($typeString);
             if ($type === null) {
                 $output->writeln("<error>Invalid package manager type: '{$typeString}'. Valid types: composer, npmjs</error>");
+
                 return null;
             }
             $excludeTypesArray[] = $type;
         }
 
         // Return all types except the excluded ones
-        return array_filter($allTypes, fn (PackageManagerType $type) => !in_array($type, $excludeTypesArray));
+        return array_filter($allTypes, fn (PackageManagerType $type) => ! in_array($type, $excludeTypesArray));
     }
 
     private function parsePackageManagerType(string $typeString): ?PackageManagerType

--- a/src/Commands/BetweenCommand.php
+++ b/src/Commands/BetweenCommand.php
@@ -44,7 +44,7 @@ class BetweenCommand extends Command
         // Passthrough the input options to the Analyse command
         $options = array_filter($input->getOptions(), fn ($value) => $value !== null);
         $options = array_combine(
-            keys: array_map(fn ($key) => '--' . $key, array_keys($options)),
+            keys: array_map(fn ($key) => '--'.$key, array_keys($options)),
             values: $options
         );
 

--- a/src/Commands/ChangelogCommand.php
+++ b/src/Commands/ChangelogCommand.php
@@ -16,13 +16,13 @@ use Whatsdiff\Analyzers\PackageManagerType;
 use Whatsdiff\Analyzers\Registries\NpmRegistry;
 use Whatsdiff\Analyzers\Registries\PackagistRegistry;
 use Whatsdiff\Analyzers\ReleaseNotes\ReleaseNotesResolver;
+use Whatsdiff\Helpers\CommandErrorHandler;
+use Whatsdiff\Helpers\VersionNormalizer;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesJsonOutput;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesMarkdownOutput;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesTextOutput;
 use Whatsdiff\Services\CacheService;
-use Whatsdiff\Helpers\CommandErrorHandler;
 use Whatsdiff\Services\GitRepository;
-use Whatsdiff\Helpers\VersionNormalizer;
 
 #[AsCommand(
     name: 'changelog',
@@ -544,7 +544,7 @@ class ChangelogCommand extends Command
             ? "vendor/{$package}"
             : "node_modules/{$package}";
 
-        $fullPath = $basePath . DIRECTORY_SEPARATOR . $relativePath;
+        $fullPath = $basePath.DIRECTORY_SEPARATOR.$relativePath;
 
         return file_exists($fullPath) ? $fullPath : null;
     }

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -27,6 +27,7 @@ class CheckCommand extends Command
     ) {
         parent::__construct();
     }
+
     protected function configure(): void
     {
         $this
@@ -117,10 +118,10 @@ class CheckCommand extends Command
     private function determineCheckType(InputInterface $input): CheckType
     {
         $options = [
-            'is-updated'    => CheckType::Updated,
+            'is-updated' => CheckType::Updated,
             'is-downgraded' => CheckType::Downgraded,
-            'is-removed'    => CheckType::Removed,
-            'is-added'      => CheckType::Added,
+            'is-removed' => CheckType::Removed,
+            'is-added' => CheckType::Added,
         ];
 
         foreach ($options as $option => $type) {

--- a/src/Commands/ConfigCommand.php
+++ b/src/Commands/ConfigCommand.php
@@ -24,6 +24,7 @@ class ConfigCommand extends Command
     ) {
         parent::__construct();
     }
+
     protected function configure(): void
     {
         $this
@@ -37,8 +38,7 @@ class ConfigCommand extends Command
                 'value',
                 InputArgument::OPTIONAL,
                 'Value to set'
-            )
-        ;
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -50,6 +50,7 @@ class ConfigCommand extends Command
         if ($key === null) {
             $config = $this->configService->getAll();
             $output->writeln(Yaml::dump($config, 4, 2));
+
             return Command::SUCCESS;
         }
 
@@ -59,6 +60,7 @@ class ConfigCommand extends Command
 
             if ($configValue === null) {
                 $output->writeln("<error>Configuration key '{$key}' not found</error>");
+
                 return Command::FAILURE;
             }
 
@@ -95,6 +97,7 @@ class ConfigCommand extends Command
             if (strpos($value, '.') !== false) {
                 return (float) $value;
             }
+
             return (int) $value;
         }
 

--- a/src/Commands/SharedCommandOptions.php
+++ b/src/Commands/SharedCommandOptions.php
@@ -49,7 +49,7 @@ trait SharedCommandOptions
      *
      * This option allows users to specify the output format (text, json, markdown).
      *
-     * @param string $default Default format (typically 'text')
+     * @param  string  $default  Default format (typically 'text')
      */
     protected function addFormatOption(string $default = 'text'): self
     {
@@ -67,7 +67,7 @@ trait SharedCommandOptions
      *
      * This option allows users to specify a starting commit/branch/tag.
      *
-     * @param string $description Custom description (optional)
+     * @param  string  $description  Custom description (optional)
      */
     protected function addFromOption(string $description = 'Git commit, branch, or tag to get the starting version from'): self
     {
@@ -84,7 +84,7 @@ trait SharedCommandOptions
      *
      * This option allows users to specify an ending commit/branch/tag.
      *
-     * @param string $description Custom description (optional)
+     * @param  string  $description  Custom description (optional)
      */
     protected function addToOption(string $description = 'Git commit, branch, or tag to get the ending version from (defaults to HEAD)'): self
     {

--- a/src/Commands/TuiCommand.php
+++ b/src/Commands/TuiCommand.php
@@ -90,8 +90,9 @@ class TuiCommand extends Command
 
             $result = $this->diffCalculator->run();
 
-            if (!$result->hasAnyChanges()) {
+            if (! $result->hasAnyChanges()) {
                 $output->writeln('<info>No dependency changes detected.</info>');
+
                 return Command::SUCCESS;
             }
 

--- a/src/Data/DependencyDiff.php
+++ b/src/Data/DependencyDiff.php
@@ -11,7 +11,7 @@ use Whatsdiff\Enums\ChangeStatus;
 final readonly class DependencyDiff
 {
     /**
-     * @param Collection<int, PackageChange> $changes
+     * @param  Collection<int, PackageChange>  $changes
      */
     public function __construct(
         public string $filename,
@@ -20,8 +20,7 @@ final readonly class DependencyDiff
         public ?string $toCommit,
         public Collection $changes,
         public bool $isNew = false,
-    ) {
-    }
+    ) {}
 
     public function hasChanges(): bool
     {

--- a/src/Data/DependencyFile.php
+++ b/src/Data/DependencyFile.php
@@ -9,7 +9,7 @@ use Whatsdiff\Analyzers\PackageManagerType;
 final readonly class DependencyFile
 {
     /**
-     * @param array<string> $commitLogs
+     * @param  array<string>  $commitLogs
      */
     public function __construct(
         public string $file,
@@ -17,8 +17,7 @@ final readonly class DependencyFile
         public bool $hasBeenRecentlyUpdated,
         public bool $hasCommitLogs,
         public array $commitLogs,
-    ) {
-    }
+    ) {}
 
     public static function create(PackageManagerType $type, string $file): self
     {

--- a/src/Data/DiffResult.php
+++ b/src/Data/DiffResult.php
@@ -9,13 +9,12 @@ use Illuminate\Support\Collection;
 final readonly class DiffResult
 {
     /**
-     * @param Collection<int, DependencyDiff> $diffs
+     * @param  Collection<int, DependencyDiff>  $diffs
      */
     public function __construct(
         public Collection $diffs,
         public bool $hasUncommittedChanges = false,
-    ) {
-    }
+    ) {}
 
     public function hasDiffs(): bool
     {

--- a/src/Data/PackageChange.php
+++ b/src/Data/PackageChange.php
@@ -11,7 +11,7 @@ use Whatsdiff\Enums\Semver;
 final readonly class PackageChange
 {
     /**
-     * @param array<SecurityAdvisory> $fixedAdvisories
+     * @param  array<SecurityAdvisory>  $fixedAdvisories
      */
     public function __construct(
         public string $name,
@@ -22,8 +22,7 @@ final readonly class PackageChange
         public ?int $releaseCount = null,
         public ?Semver $semver = null,
         public array $fixedAdvisories = [],
-    ) {
-    }
+    ) {}
 
     public static function added(string $name, PackageManagerType $type, string $version): self
     {
@@ -48,7 +47,7 @@ final readonly class PackageChange
     }
 
     /**
-     * @param array<SecurityAdvisory> $fixedAdvisories
+     * @param  array<SecurityAdvisory>  $fixedAdvisories
      */
     public static function updated(
         string $name,
@@ -72,7 +71,7 @@ final readonly class PackageChange
     }
 
     /**
-     * @param array<SecurityAdvisory> $fixedAdvisories
+     * @param  array<SecurityAdvisory>  $fixedAdvisories
      */
     public static function downgraded(
         string $name,

--- a/src/Data/ReleaseNote.php
+++ b/src/Data/ReleaseNote.php
@@ -72,7 +72,7 @@ final readonly class ReleaseNote
      */
     public function getChanges(): array
     {
-        if (!$this->isStructured()) {
+        if (! $this->isStructured()) {
             return [];
         }
 
@@ -86,7 +86,7 @@ final readonly class ReleaseNote
      */
     public function getFixes(): array
     {
-        if (!$this->isStructured()) {
+        if (! $this->isStructured()) {
             return [];
         }
 
@@ -100,7 +100,7 @@ final readonly class ReleaseNote
      */
     public function getBreakingChanges(): array
     {
-        if (!$this->isStructured()) {
+        if (! $this->isStructured()) {
             return [];
         }
 
@@ -114,7 +114,7 @@ final readonly class ReleaseNote
      */
     public function getDeprecated(): array
     {
-        if (!$this->isStructured()) {
+        if (! $this->isStructured()) {
             return [];
         }
 
@@ -128,7 +128,7 @@ final readonly class ReleaseNote
      */
     public function getRemoved(): array
     {
-        if (!$this->isStructured()) {
+        if (! $this->isStructured()) {
             return [];
         }
 
@@ -142,7 +142,7 @@ final readonly class ReleaseNote
      */
     public function getSecurity(): array
     {
-        if (!$this->isStructured()) {
+        if (! $this->isStructured()) {
             return [];
         }
 
@@ -198,7 +198,7 @@ final readonly class ReleaseNote
      */
     public function getDescription(): string
     {
-        if (!$this->isStructured()) {
+        if (! $this->isStructured()) {
             return '';
         }
 
@@ -222,14 +222,15 @@ final readonly class ReleaseNote
                     || preg_match('/\*\*\s*(Changed?|Added?|What\'?s Changed|New Features|Features|Enhancements|Improvements|Fixes?|Fixed|Bug ?Fixes?|Bugfixes|Breaking( Changes)?|BREAKING CHANGES|Removed?|Deprecated|Security)\s*\*\*/i', $trimmedLine);
 
                 $inRecognizedSection = (bool) $isRecognized;
+
                 continue;
             }
 
             // If we haven't seen any heading yet, or we're in an unrecognized section,
             // and this isn't a bullet point, collect it as description
-            if ((!$hasSeenHeading || !$inRecognizedSection) &&
-                !str_starts_with($trimmedLine, '- ') &&
-                !str_starts_with($trimmedLine, '* ')) {
+            if ((! $hasSeenHeading || ! $inRecognizedSection) &&
+                ! str_starts_with($trimmedLine, '- ') &&
+                ! str_starts_with($trimmedLine, '* ')) {
                 $description[] = $line; // Keep original line with indentation
             }
         }
@@ -249,7 +250,7 @@ final readonly class ReleaseNote
      *
      * This method also supports bold headings like **Changes** in addition to markdown headings.
      *
-     * @param string $headingPattern Regex pattern to match section headings
+     * @param  string  $headingPattern  Regex pattern to match section headings
      * @return array<int, string>
      */
     private function extractSectionByPattern(string $headingPattern): array
@@ -272,6 +273,7 @@ final readonly class ReleaseNote
             // Check if we're starting a section we care about
             if (preg_match($headingPattern, $trimmedLine) || preg_match($boldPattern, $trimmedLine)) {
                 $inSection = true;
+
                 continue; // Skip the heading line itself
             }
 
@@ -282,9 +284,10 @@ final readonly class ReleaseNote
 
             if ($inSection && $isNewSection) {
                 // Check if this new section matches our pattern
-                if (!preg_match($headingPattern, $trimmedLine) && !preg_match($boldPattern, $trimmedLine)) {
+                if (! preg_match($headingPattern, $trimmedLine) && ! preg_match($boldPattern, $trimmedLine)) {
                     $inSection = false;
                 }
+
                 continue;
             }
 

--- a/src/Data/ReleaseNotesCollection.php
+++ b/src/Data/ReleaseNotesCollection.php
@@ -17,12 +17,11 @@ use Whatsdiff\Helpers\GithubUrlFormatter;
 final readonly class ReleaseNotesCollection implements Countable, IteratorAggregate
 {
     /**
-     * @param array<int, ReleaseNote> $releases
+     * @param  array<int, ReleaseNote>  $releases
      */
     public function __construct(
         private array $releases = []
-    ) {
-    }
+    ) {}
 
     /**
      * Get all release notes.
@@ -157,7 +156,7 @@ final readonly class ReleaseNotesCollection implements Countable, IteratorAggreg
         foreach ($this->releases as $release) {
             $markdown .= "## {$release->tagName}";
 
-            if (!empty($release->title) && $release->title !== $release->tagName) {
+            if (! empty($release->title) && $release->title !== $release->tagName) {
                 $markdown .= " - {$release->title}";
             }
 
@@ -197,20 +196,21 @@ final readonly class ReleaseNotesCollection implements Countable, IteratorAggreg
         // If any release is unstructured, show all bullet points in a flat list
         if ($this->hasUnstructuredReleases()) {
             $allBulletPoints = $this->getAllBulletPoints();
-            if (!empty($allBulletPoints)) {
+            if (! empty($allBulletPoints)) {
                 $markdown .= "## All Changes\n\n";
                 foreach ($allBulletPoints as $bulletPoint) {
                     $markdown .= "- {$this->formatGithubUrls($bulletPoint)}\n";
                 }
                 $markdown .= "\n";
             }
+
             return trim($markdown);
         }
 
         // All releases are structured - show categorized sections
         // Breaking Changes section
         $breakingChanges = $this->getBreakingChanges();
-        if (!empty($breakingChanges)) {
+        if (! empty($breakingChanges)) {
             $markdown .= "## Breaking Changes\n\n";
             foreach ($breakingChanges as $change) {
                 $markdown .= "- {$this->formatGithubUrls($change)}\n";
@@ -220,7 +220,7 @@ final readonly class ReleaseNotesCollection implements Countable, IteratorAggreg
 
         // Changes section
         $changes = $this->getChanges();
-        if (!empty($changes)) {
+        if (! empty($changes)) {
             $markdown .= "## Changes\n\n";
             foreach ($changes as $change) {
                 $markdown .= "- {$this->formatGithubUrls($change)}\n";
@@ -230,7 +230,7 @@ final readonly class ReleaseNotesCollection implements Countable, IteratorAggreg
 
         // Fixes section
         $fixes = $this->getFixes();
-        if (!empty($fixes)) {
+        if (! empty($fixes)) {
             $markdown .= "## Fixes\n\n";
             foreach ($fixes as $fix) {
                 $markdown .= "- {$this->formatGithubUrls($fix)}\n";
@@ -240,7 +240,7 @@ final readonly class ReleaseNotesCollection implements Countable, IteratorAggreg
 
         // Deprecated section
         $deprecated = $this->getDeprecated();
-        if (!empty($deprecated)) {
+        if (! empty($deprecated)) {
             $markdown .= "## Deprecated\n\n";
             foreach ($deprecated as $item) {
                 $markdown .= "- {$this->formatGithubUrls($item)}\n";
@@ -250,7 +250,7 @@ final readonly class ReleaseNotesCollection implements Countable, IteratorAggreg
 
         // Removed section
         $removed = $this->getRemoved();
-        if (!empty($removed)) {
+        if (! empty($removed)) {
             $markdown .= "## Removed\n\n";
             foreach ($removed as $item) {
                 $markdown .= "- {$this->formatGithubUrls($item)}\n";
@@ -260,7 +260,7 @@ final readonly class ReleaseNotesCollection implements Countable, IteratorAggreg
 
         // Security section
         $security = $this->getSecurity();
-        if (!empty($security)) {
+        if (! empty($security)) {
             $markdown .= "## Security\n\n";
             foreach ($security as $item) {
                 $markdown .= "- {$this->formatGithubUrls($item)}\n";
@@ -306,7 +306,7 @@ final readonly class ReleaseNotesCollection implements Countable, IteratorAggreg
     public function hasUnstructuredReleases(): bool
     {
         foreach ($this->releases as $release) {
-            if (!$release->isStructured()) {
+            if (! $release->isStructured()) {
                 return true;
             }
         }

--- a/src/Data/SecurityAdvisory.php
+++ b/src/Data/SecurityAdvisory.php
@@ -12,6 +12,5 @@ final readonly class SecurityAdvisory
         public string $title,
         public string $link,
         public string $affectedVersions,
-    ) {
-    }
+    ) {}
 }

--- a/src/Helpers/CommandErrorHandler.php
+++ b/src/Helpers/CommandErrorHandler.php
@@ -22,10 +22,10 @@ class CommandErrorHandler
      * - JSON format: Returns structured JSON with error message
      * - Text format: Returns styled console error message
      *
-     * @param \Exception $exception The exception that was caught
-     * @param OutputInterface $output Symfony Console output interface
-     * @param string|null $format Output format (json, text, markdown, etc.)
-     * @param int $exitCode The command exit code to return (default: Command::FAILURE)
+     * @param  \Exception  $exception  The exception that was caught
+     * @param  OutputInterface  $output  Symfony Console output interface
+     * @param  string|null  $format  Output format (json, text, markdown, etc.)
+     * @param  int  $exitCode  The command exit code to return (default: Command::FAILURE)
      * @return int The exit code to return from the command
      */
     public static function handle(
@@ -54,10 +54,10 @@ class CommandErrorHandler
      * Useful for commands that support a --quiet flag where errors should
      * only be displayed when quiet mode is not enabled.
      *
-     * @param \Exception $exception The exception that was caught
-     * @param OutputInterface $output Symfony Console output interface
-     * @param bool $quiet Whether quiet mode is enabled
-     * @param int $exitCode The command exit code to return (default: Command::INVALID)
+     * @param  \Exception  $exception  The exception that was caught
+     * @param  OutputInterface  $output  Symfony Console output interface
+     * @param  bool  $quiet  Whether quiet mode is enabled
+     * @param  int  $exitCode  The command exit code to return (default: Command::INVALID)
      * @return int The exit code to return from the command
      */
     public static function handleQuiet(
@@ -66,7 +66,7 @@ class CommandErrorHandler
         bool $quiet,
         int $exitCode = Command::INVALID
     ): int {
-        if (!$quiet) {
+        if (! $quiet) {
             $output->writeln("<error>Error: {$exception->getMessage()}</error>");
         }
 
@@ -78,10 +78,10 @@ class CommandErrorHandler
      *
      * Allows for more control over the error message format and structure.
      *
-     * @param \Exception $exception The exception that was caught
-     * @param OutputInterface $output Symfony Console output interface
-     * @param callable $formatter Custom formatter function (receives exception, returns string)
-     * @param int $exitCode The command exit code to return (default: Command::FAILURE)
+     * @param  \Exception  $exception  The exception that was caught
+     * @param  OutputInterface  $output  Symfony Console output interface
+     * @param  callable  $formatter  Custom formatter function (receives exception, returns string)
+     * @param  int  $exitCode  The command exit code to return (default: Command::FAILURE)
      * @return int The exit code to return from the command
      */
     public static function handleWithFormatter(

--- a/src/Helpers/GithubUrlFormatter.php
+++ b/src/Helpers/GithubUrlFormatter.php
@@ -22,7 +22,7 @@ class GithubUrlFormatter
     public static function toTerminalLink(string $text): string
     {
         return preg_replace(
-            '/(?<!href=)(' . self::PATTERN . ')/',
+            '/(?<!href=)('.self::PATTERN.')/',
             '<href=$1>#$2</>',
             $text
         );
@@ -35,7 +35,7 @@ class GithubUrlFormatter
     public static function toMarkdownLink(string $text): string
     {
         return preg_replace(
-            '/(?<!\()' . self::PATTERN . '/',
+            '/(?<!\()'.self::PATTERN.'/',
             '[#$1]($0)',
             $text
         );
@@ -48,7 +48,7 @@ class GithubUrlFormatter
     public static function toShortText(string $text): string
     {
         return preg_replace(
-            '/' . self::PATTERN . '/',
+            '/'.self::PATTERN.'/',
             '#$1',
             $text
         );

--- a/src/Helpers/SemverAnalyzer.php
+++ b/src/Helpers/SemverAnalyzer.php
@@ -20,7 +20,7 @@ final class SemverAnalyzer
     private static function getParser(): VersionParser
     {
         if (self::$versionParser === null) {
-            self::$versionParser = new VersionParser();
+            self::$versionParser = new VersionParser;
         }
 
         return self::$versionParser;
@@ -29,8 +29,8 @@ final class SemverAnalyzer
     /**
      * Determine the type of semantic version change between two versions.
      *
-     * @param string $fromVersion Starting version
-     * @param string $toVersion Ending version
+     * @param  string  $fromVersion  Starting version
+     * @param  string  $toVersion  Ending version
      * @return Semver|null Major, Minor, Patch, or null if cannot be determined
      */
     public static function determineSemverChangeType(string $fromVersion, string $toVersion): ?Semver
@@ -65,7 +65,7 @@ final class SemverAnalyzer
     /**
      * Parse a version string into major, minor, and patch components.
      *
-     * @param string $version Version string
+     * @param  string  $version  Version string
      * @return array{major: int, minor: int, patch: int}|null
      */
     private static function parseVersion(string $version): ?array
@@ -76,7 +76,7 @@ final class SemverAnalyzer
             return null;
         }
 
-        if (!preg_match('/^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?(?:\+(.+))?$/', $normalized, $matches)) {
+        if (! preg_match('/^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?(?:\+(.+))?$/', $normalized, $matches)) {
             return null;
         }
 
@@ -90,8 +90,7 @@ final class SemverAnalyzer
     /**
      * Check if a version is a development version.
      *
-     * @param string $version Version string
-     * @return bool
+     * @param  string  $version  Version string
      */
     private static function isDevVersion(string $version): bool
     {

--- a/src/Helpers/VersionNormalizer.php
+++ b/src/Helpers/VersionNormalizer.php
@@ -24,7 +24,7 @@ class VersionNormalizer
     private static function getParser(): VersionParser
     {
         if (self::$versionParser === null) {
-            self::$versionParser = new VersionParser();
+            self::$versionParser = new VersionParser;
         }
 
         return self::$versionParser;
@@ -43,8 +43,9 @@ class VersionNormalizer
      * - "2.0" -> "2.0.0.0"
      * - "1.0.0-beta1" -> "1.0.0.0-beta1"
      *
-     * @param string $version Version string to normalize
+     * @param  string  $version  Version string to normalize
      * @return string Fully normalized semver string
+     *
      * @throws \UnexpectedValueException If version string is invalid
      */
     public static function normalize(string $version): string
@@ -60,7 +61,7 @@ class VersionNormalizer
      * - "V2.0.0" -> "2.0.0"
      * - "1.0.0" -> "1.0.0"
      *
-     * @param string $version Version string
+     * @param  string  $version  Version string
      * @return string Version string without prefix
      */
     public static function stripPrefix(string $version): string

--- a/src/Mcp/Tools/FindCompatibleVersionTool.php
+++ b/src/Mcp/Tools/FindCompatibleVersionTool.php
@@ -20,7 +20,7 @@ class FindCompatibleVersionTool
         private PackagistRegistry $packagistRegistry,
         private NpmRegistry $npmRegistry
     ) {
-        $this->versionParser = new VersionParser();
+        $this->versionParser = new VersionParser;
     }
 
     #[McpTool(
@@ -95,7 +95,7 @@ class FindCompatibleVersionTool
                 PackageManagerType::NPM => $versionData['dependencies'] ?? [],
             };
 
-            if (!isset($requires[$dependency_package])) {
+            if (! isset($requires[$dependency_package])) {
                 continue;
             }
 
@@ -114,7 +114,7 @@ class FindCompatibleVersionTool
 
                 // Check if the constraints intersect using composer/semver's interval arithmetic
                 if (Intervals::haveIntersections($requiredConstraint, $normalizedConstraint)) {
-                    if (!isset($majorVersions[$majorVersion])) {
+                    if (! isset($majorVersions[$majorVersion])) {
                         $majorVersions[$majorVersion] = [
                             'major_version' => $majorVersion,
                             'example_version' => $version,

--- a/src/Mcp/Tools/GetAvailableUpgradesTool.php
+++ b/src/Mcp/Tools/GetAvailableUpgradesTool.php
@@ -20,7 +20,7 @@ class GetAvailableUpgradesTool
         private PackagistRegistry $packagistRegistry,
         private NpmRegistry $npmRegistry
     ) {
-        $this->versionParser = new VersionParser();
+        $this->versionParser = new VersionParser;
     }
 
     #[McpTool(
@@ -60,7 +60,7 @@ class GetAvailableUpgradesTool
             ];
         }
 
-        if (!preg_match('/^(\d+)\.(\d+)\.(\d+)/', $normalized, $matches)) {
+        if (! preg_match('/^(\d+)\.(\d+)\.(\d+)/', $normalized, $matches)) {
             return [
                 'error' => 'Could not parse version number',
                 'package' => $package,
@@ -105,7 +105,7 @@ class GetAvailableUpgradesTool
             }
 
             // Skip pre-release versions unless explicitly requested
-            if (!$include_prerelease) {
+            if (! $include_prerelease) {
                 try {
                     $stability = $this->versionParser->parseStability($version);
                     if ($stability !== 'stable') {
@@ -131,13 +131,13 @@ class GetAvailableUpgradesTool
                 $normalizedVersion = ltrim($version, 'vV');
 
                 // Skip if version is not greater than current
-                if (!Comparator::greaterThan($normalizedVersion, $normalizedCurrentVersion)) {
+                if (! Comparator::greaterThan($normalizedVersion, $normalizedCurrentVersion)) {
                     continue;
                 }
 
                 // Parse version
                 $vNormalized = $this->versionParser->normalize($normalizedVersion);
-                if (!preg_match('/^(\d+)\.(\d+)\.(\d+)/', $vNormalized, $vMatches)) {
+                if (! preg_match('/^(\d+)\.(\d+)\.(\d+)/', $vNormalized, $vMatches)) {
                     continue;
                 }
 

--- a/src/Mcp/Tools/GetDependencyConstraintsTool.php
+++ b/src/Mcp/Tools/GetDependencyConstraintsTool.php
@@ -15,8 +15,7 @@ class GetDependencyConstraintsTool
     public function __construct(
         private PackagistRegistry $packagistRegistry,
         private NpmRegistry $npmRegistry
-    ) {
-    }
+    ) {}
 
     #[McpTool(
         name: 'get_dependency_constraints',
@@ -41,7 +40,7 @@ class GetDependencyConstraintsTool
 
         // Normalize version (remove 'v' prefix for searching)
         $searchVersion = ltrim($version, 'vV');
-        $vVersion = 'v' . $searchVersion;
+        $vVersion = 'v'.$searchVersion;
 
         // Fetch package metadata
         try {

--- a/src/Mcp/Tools/GetReleaseNotesTool.php
+++ b/src/Mcp/Tools/GetReleaseNotesTool.php
@@ -16,8 +16,7 @@ class GetReleaseNotesTool
         private ReleaseNotesResolver $releaseNotesResolver,
         private PackagistRegistry $packagistRegistry,
         private NpmRegistry $npmRegistry
-    ) {
-    }
+    ) {}
 
     #[McpTool(
         name: 'get_release_notes',

--- a/src/Outputs/MarkdownOutput.php
+++ b/src/Outputs/MarkdownOutput.php
@@ -14,8 +14,9 @@ class MarkdownOutput implements OutputFormatterInterface
 {
     public function format(DiffResult $result, OutputInterface $output): void
     {
-        if (!$result->hasAnyChanges()) {
+        if (! $result->hasAnyChanges()) {
             $output->writeln('No dependency changes detected.');
+
             return;
         }
 
@@ -34,7 +35,7 @@ class MarkdownOutput implements OutputFormatterInterface
 
     private function formatDiff(DependencyDiff $diff, OutputInterface $output): void
     {
-        if (!$diff->hasChanges()) {
+        if (! $diff->hasChanges()) {
             return;
         }
 
@@ -110,7 +111,7 @@ class MarkdownOutput implements OutputFormatterInterface
 
         // Security Advisories Fixed section
         $allChangesWithAdvisories = $diff->changes
-            ->filter(fn (PackageChange $change) => !empty($change->fixedAdvisories));
+            ->filter(fn (PackageChange $change) => ! empty($change->fixedAdvisories));
 
         if ($allChangesWithAdvisories->isNotEmpty()) {
             $output->writeln('### Security Advisories Fixed');

--- a/src/Outputs/ReleaseNotes/ReleaseNotesJsonOutput.php
+++ b/src/Outputs/ReleaseNotes/ReleaseNotesJsonOutput.php
@@ -11,20 +11,19 @@ class ReleaseNotesJsonOutput
 {
     public function __construct(
         private bool $summary = false
-    ) {
-    }
+    ) {}
 
     public function format(ReleaseNotesCollection $collection, OutputInterface $output): void
     {
         $releases = $collection->getReleases();
-        $isStructured = !$collection->hasUnstructuredReleases();
+        $isStructured = ! $collection->hasUnstructuredReleases();
 
         $data = [
             'total_releases' => $collection->count(),
         ];
 
         // Add version range and summary only if there are releases
-        if (!empty($releases)) {
+        if (! empty($releases)) {
             $data['first_tag'] = $releases[0]->tagName;
             $data['last_tag'] = $releases[count($releases) - 1]->tagName;
 

--- a/src/Outputs/ReleaseNotes/ReleaseNotesMarkdownOutput.php
+++ b/src/Outputs/ReleaseNotes/ReleaseNotesMarkdownOutput.php
@@ -11,8 +11,7 @@ class ReleaseNotesMarkdownOutput
 {
     public function __construct(
         private bool $summary = false,
-    ) {
-    }
+    ) {}
 
     public function format(ReleaseNotesCollection $collection, OutputInterface $output): void
     {

--- a/src/Outputs/ReleaseNotes/ReleaseNotesTextOutput.php
+++ b/src/Outputs/ReleaseNotes/ReleaseNotesTextOutput.php
@@ -14,8 +14,7 @@ class ReleaseNotesTextOutput
     public function __construct(
         private bool $summary = false,
         private bool $useAnsi = true,
-    ) {
-    }
+    ) {}
 
     public function format(ReleaseNotesCollection $collection, OutputInterface $output): void
     {
@@ -36,7 +35,7 @@ class ReleaseNotesTextOutput
     {
         $output->writeln('');
         $output->writeln($this->colorize('<fg=bright-cyan>Release Notes</>', 'Release Notes'));
-        $output->writeln($this->colorize('<fg=gray>' . str_repeat('─', 80) . '</>', str_repeat('-', 80)));
+        $output->writeln($this->colorize('<fg=gray>'.str_repeat('─', 80).'</>', str_repeat('-', 80)));
         $output->writeln('');
 
         foreach ($collection as $release) {
@@ -49,30 +48,30 @@ class ReleaseNotesTextOutput
     {
         // Release header
         $header = $release->tagName;
-        if (!empty($release->title) && $release->title !== $release->tagName) {
-            $header .= ' - ' . $release->title;
+        if (! empty($release->title) && $release->title !== $release->tagName) {
+            $header .= ' - '.$release->title;
         }
-        $output->writeln($this->colorize('<fg=bright-yellow>' . $header . '</>', $header));
+        $output->writeln($this->colorize('<fg=bright-yellow>'.$header.'</>', $header));
 
         // Date and URL
-        $output->writeln($this->colorize('<fg=gray>Date: ' . $release->date->format('Y-m-d') . '</>', 'Date: ' . $release->date->format('Y-m-d')));
+        $output->writeln($this->colorize('<fg=gray>Date: '.$release->date->format('Y-m-d').'</>', 'Date: '.$release->date->format('Y-m-d')));
         if ($release->url) {
-            $urlText = '<href=' . $release->url . '>' . $release->url . '</>';
-            $output->writeln($this->colorize('<fg=gray>URL: ' . $urlText . '</>', 'URL: ' . $release->url));
+            $urlText = '<href='.$release->url.'>'.$release->url.'</>';
+            $output->writeln($this->colorize('<fg=gray>URL: '.$urlText.'</>', 'URL: '.$release->url));
         }
         $output->writeln('');
 
         // If changelog is not structured, display raw body
-        if (!$release->isStructured()) {
+        if (! $release->isStructured()) {
             $body = $release->getBody();
-            if (!empty($body)) {
+            if (! empty($body)) {
                 $bodyLines = explode("\n", $body);
                 foreach ($bodyLines as $line) {
                     if (trim($line) === '') {
                         $output->writeln('');
                     } else {
                         $formatted = $this->formatTextWithLinks($line);
-                        $output->writeln($this->colorize('<fg=default>' . $formatted . '</>', $line));
+                        $output->writeln($this->colorize('<fg=default>'.$formatted.'</>', $line));
                     }
                 }
                 $output->writeln('');
@@ -88,7 +87,7 @@ class ReleaseNotesTextOutput
                         $output->writeln('');
                     } else {
                         $formatted = $this->formatTextWithLinks($line);
-                        $output->writeln($this->colorize('<fg=default>' . $formatted . '</>', $line));
+                        $output->writeln($this->colorize('<fg=default>'.$formatted.'</>', $line));
                     }
                 }
                 $output->writeln('');
@@ -100,7 +99,7 @@ class ReleaseNotesTextOutput
                 $output->writeln($this->colorize('<fg=bright-red>Breaking Changes:</>', 'Breaking Changes:'));
                 foreach ($breakingChanges as $change) {
                     $formatted = $this->formatTextWithLinks($change);
-                    $output->writeln($this->colorize('  <fg=red>•</> ' . $formatted, '  • ' . $change));
+                    $output->writeln($this->colorize('  <fg=red>•</> '.$formatted, '  • '.$change));
                 }
                 $output->writeln('');
             }
@@ -111,7 +110,7 @@ class ReleaseNotesTextOutput
                 $output->writeln($this->colorize('<fg=bright-green>Changes:</>', 'Changes:'));
                 foreach ($changes as $change) {
                     $formatted = $this->formatTextWithLinks($change);
-                    $output->writeln($this->colorize('  <fg=green>•</> ' . $formatted, '  • ' . $change));
+                    $output->writeln($this->colorize('  <fg=green>•</> '.$formatted, '  • '.$change));
                 }
                 $output->writeln('');
             }
@@ -122,7 +121,7 @@ class ReleaseNotesTextOutput
                 $output->writeln($this->colorize('<fg=bright-blue>Fixes:</>', 'Fixes:'));
                 foreach ($fixes as $fix) {
                     $formatted = $this->formatTextWithLinks($fix);
-                    $output->writeln($this->colorize('  <fg=blue>•</> ' . $formatted, '  • ' . $fix));
+                    $output->writeln($this->colorize('  <fg=blue>•</> '.$formatted, '  • '.$fix));
                 }
                 $output->writeln('');
             }
@@ -133,7 +132,7 @@ class ReleaseNotesTextOutput
                 $output->writeln($this->colorize('<fg=bright-yellow>Deprecated:</>', 'Deprecated:'));
                 foreach ($deprecated as $item) {
                     $formatted = $this->formatTextWithLinks($item);
-                    $output->writeln($this->colorize('  <fg=yellow>•</> ' . $formatted, '  • ' . $item));
+                    $output->writeln($this->colorize('  <fg=yellow>•</> '.$formatted, '  • '.$item));
                 }
                 $output->writeln('');
             }
@@ -144,7 +143,7 @@ class ReleaseNotesTextOutput
                 $output->writeln($this->colorize('<fg=bright-red>Removed:</>', 'Removed:'));
                 foreach ($removed as $item) {
                     $formatted = $this->formatTextWithLinks($item);
-                    $output->writeln($this->colorize('  <fg=red>•</> ' . $formatted, '  • ' . $item));
+                    $output->writeln($this->colorize('  <fg=red>•</> '.$formatted, '  • '.$item));
                 }
                 $output->writeln('');
             }
@@ -155,20 +154,20 @@ class ReleaseNotesTextOutput
                 $output->writeln($this->colorize('<fg=bright-magenta>Security:</>', 'Security:'));
                 foreach ($security as $item) {
                     $formatted = $this->formatTextWithLinks($item);
-                    $output->writeln($this->colorize('  <fg=magenta>•</> ' . $formatted, '  • ' . $item));
+                    $output->writeln($this->colorize('  <fg=magenta>•</> '.$formatted, '  • '.$item));
                 }
                 $output->writeln('');
             }
         }
 
-        $output->writeln($this->colorize('<fg=gray>' . str_repeat('─', 80) . '</>', str_repeat('-', 80)));
+        $output->writeln($this->colorize('<fg=gray>'.str_repeat('─', 80).'</>', str_repeat('-', 80)));
     }
 
     private function formatSummary(ReleaseNotesCollection $collection, OutputInterface $output): void
     {
         $output->writeln('');
         $output->writeln($this->colorize('<fg=bright-cyan>Release Notes Summary</>', 'Release Notes Summary'));
-        $output->writeln($this->colorize('<fg=gray>' . str_repeat('─', 80) . '</>', str_repeat('-', 80)));
+        $output->writeln($this->colorize('<fg=gray>'.str_repeat('─', 80).'</>', str_repeat('-', 80)));
         $output->writeln('');
 
         // Show version range and count
@@ -178,20 +177,21 @@ class ReleaseNotesTextOutput
         $count = $collection->count();
         $releasesInfo = "Changelog of: {$lastTag} → {$firstTag} ({$count} versions)";
 
-        $output->writeln($this->colorize('<fg=gray>' . $releasesInfo . '</>', $releasesInfo));
+        $output->writeln($this->colorize('<fg=gray>'.$releasesInfo.'</>', $releasesInfo));
         $output->writeln('');
 
         // If any release is unstructured, show all bullet points in a flat list
         if ($collection->hasUnstructuredReleases()) {
             $allBulletPoints = $collection->getAllBulletPoints();
-            if (!empty($allBulletPoints)) {
+            if (! empty($allBulletPoints)) {
                 $output->writeln($this->colorize('<fg=bright-green>Changes:</>', 'Changes:'));
                 foreach ($allBulletPoints as $bulletPoint) {
                     $formatted = $this->formatTextWithLinks($bulletPoint);
-                    $output->writeln($this->colorize('  <fg=green>•</> ' . $formatted, '  • ' . $bulletPoint));
+                    $output->writeln($this->colorize('  <fg=green>•</> '.$formatted, '  • '.$bulletPoint));
                 }
                 $output->writeln('');
             }
+
             return;
         }
 
@@ -202,7 +202,7 @@ class ReleaseNotesTextOutput
             $output->writeln($this->colorize('<fg=bright-red>Breaking Changes:</>', 'Breaking Changes:'));
             foreach ($breakingChanges as $change) {
                 $formatted = $this->formatTextWithLinks($change);
-                $output->writeln($this->colorize('  <fg=red>•</> ' . $formatted, '  • ' . $change));
+                $output->writeln($this->colorize('  <fg=red>•</> '.$formatted, '  • '.$change));
             }
             $output->writeln('');
         }
@@ -213,7 +213,7 @@ class ReleaseNotesTextOutput
             $output->writeln($this->colorize('<fg=bright-green>Changes:</>', 'Changes:'));
             foreach ($changes as $change) {
                 $formatted = $this->formatTextWithLinks($change);
-                $output->writeln($this->colorize('  <fg=green>•</> ' . $formatted, '  • ' . $change));
+                $output->writeln($this->colorize('  <fg=green>•</> '.$formatted, '  • '.$change));
             }
             $output->writeln('');
         }
@@ -224,7 +224,7 @@ class ReleaseNotesTextOutput
             $output->writeln($this->colorize('<fg=bright-blue>Fixes:</>', 'Fixes:'));
             foreach ($fixes as $fix) {
                 $formatted = $this->formatTextWithLinks($fix);
-                $output->writeln($this->colorize('  <fg=blue>•</> ' . $formatted, '  • ' . $fix));
+                $output->writeln($this->colorize('  <fg=blue>•</> '.$formatted, '  • '.$fix));
             }
             $output->writeln('');
         }
@@ -235,7 +235,7 @@ class ReleaseNotesTextOutput
             $output->writeln($this->colorize('<fg=bright-yellow>Deprecated:</>', 'Deprecated:'));
             foreach ($deprecated as $item) {
                 $formatted = $this->formatTextWithLinks($item);
-                $output->writeln($this->colorize('  <fg=yellow>•</> ' . $formatted, '  • ' . $item));
+                $output->writeln($this->colorize('  <fg=yellow>•</> '.$formatted, '  • '.$item));
             }
             $output->writeln('');
         }
@@ -246,7 +246,7 @@ class ReleaseNotesTextOutput
             $output->writeln($this->colorize('<fg=bright-red>Removed:</>', 'Removed:'));
             foreach ($removed as $item) {
                 $formatted = $this->formatTextWithLinks($item);
-                $output->writeln($this->colorize('  <fg=red>•</> ' . $formatted, '  • ' . $item));
+                $output->writeln($this->colorize('  <fg=red>•</> '.$formatted, '  • '.$item));
             }
             $output->writeln('');
         }
@@ -257,7 +257,7 @@ class ReleaseNotesTextOutput
             $output->writeln($this->colorize('<fg=bright-magenta>Security:</>', 'Security:'));
             foreach ($security as $item) {
                 $formatted = $this->formatTextWithLinks($item);
-                $output->writeln($this->colorize('  <fg=magenta>•</> ' . $formatted, '  • ' . $item));
+                $output->writeln($this->colorize('  <fg=magenta>•</> '.$formatted, '  • '.$item));
             }
             $output->writeln('');
         }

--- a/src/Outputs/Tui/ChangelogFormatter.php
+++ b/src/Outputs/Tui/ChangelogFormatter.php
@@ -19,9 +19,9 @@ class ChangelogFormatter
     /**
      * Format release notes collection as an array of lines for TUI display.
      *
-     * @param ReleaseNotesCollection $collection The release notes to format
-     * @param bool $summary Whether to show summary view (true) or detailed view (false)
-     * @param int $maxWidth Maximum width for line wrapping
+     * @param  ReleaseNotesCollection  $collection  The release notes to format
+     * @param  bool  $summary  Whether to show summary view (true) or detailed view (false)
+     * @param  int  $maxWidth  Maximum width for line wrapping
      * @return array<int, string> Array of formatted lines ready for TUI display
      */
     public function format(ReleaseNotesCollection $collection, bool $summary, int $maxWidth): array
@@ -40,8 +40,6 @@ class ChangelogFormatter
     /**
      * Format release notes in detailed mode (each release separately).
      *
-     * @param ReleaseNotesCollection $collection
-     * @param int $maxWidth
      * @return array<int, string>
      */
     private function formatDetailed(ReleaseNotesCollection $collection, int $maxWidth): array
@@ -54,7 +52,6 @@ class ChangelogFormatter
             $lines = array_merge($lines, $this->formatRelease($release, $maxWidth));
         }
 
-
         $lines[] = '';
         $lines[] = '';
         $lines[] = '';
@@ -66,8 +63,6 @@ class ChangelogFormatter
     /**
      * Format a single release.
      *
-     * @param ReleaseNote $release
-     * @param int $maxWidth
      * @return array<int, string>
      */
     private function formatRelease(ReleaseNote $release, int $maxWidth): array
@@ -76,26 +71,26 @@ class ChangelogFormatter
 
         // Release header
         $header = $release->tagName;
-        if (!empty($release->title) && $release->title !== $release->tagName) {
-            $header .= ' - ' . $release->title;
+        if (! empty($release->title) && $release->title !== $release->tagName) {
+            $header .= ' - '.$release->title;
         }
         $lines[] = $this->yellow($this->bold($header));
 
         // Date
-        $lines[] = $this->gray('Date: ' . $release->date->format('Y-m-d'));
+        $lines[] = $this->gray('Date: '.$release->date->format('Y-m-d'));
 
         // URL (if available)
         if ($release->url) {
             // Format URL as clickable hyperlink with truncation (already fits within maxWidth)
             $clickableUrl = $this->formatClickableUrl($release->url, $maxWidth - 6);
-            $lines[] = $this->gray('URL: ') . $clickableUrl;
+            $lines[] = $this->gray('URL: ').$clickableUrl;
         }
 
         // If changelog is not structured, display raw body
-        if (!$release->isStructured()) {
+        if (! $release->isStructured()) {
             $lines[] = '';
             $body = $release->getBody();
-            if (!empty($body)) {
+            if (! empty($body)) {
                 // Format links before wrapping
                 $formattedBody = $this->formatTextWithLinks($body);
                 $bodyLines = $this->wrapText($formattedBody, $maxWidth);
@@ -106,7 +101,7 @@ class ChangelogFormatter
         } else {
             // Description (if any)
             $description = $release->getDescription();
-            if (!empty($description)) {
+            if (! empty($description)) {
                 $lines[] = '';
                 // Format links before wrapping
                 $formattedDescription = $this->formatTextWithLinks($description);
@@ -118,7 +113,7 @@ class ChangelogFormatter
 
             // Breaking changes
             $breakingChanges = $release->getBreakingChanges();
-            if (!empty($breakingChanges)) {
+            if (! empty($breakingChanges)) {
                 $lines[] = '';
                 $lines[] = $this->red($this->bold('Breaking Changes:'));
                 foreach ($breakingChanges as $change) {
@@ -127,9 +122,9 @@ class ChangelogFormatter
                     $wrappedLines = $this->wrapText($formattedChange, $maxWidth - 4);
                     foreach ($wrappedLines as $idx => $line) {
                         if ($idx === 0) {
-                            $lines[] = '  ' . $this->red('•') . ' ' . $line;
+                            $lines[] = '  '.$this->red('•').' '.$line;
                         } else {
-                            $lines[] = '    ' . $line;
+                            $lines[] = '    '.$line;
                         }
                     }
                 }
@@ -137,7 +132,7 @@ class ChangelogFormatter
 
             // Changes
             $changes = $release->getChanges();
-            if (!empty($changes)) {
+            if (! empty($changes)) {
                 $lines[] = '';
                 $lines[] = $this->green($this->bold('Changes:'));
                 foreach ($changes as $change) {
@@ -146,9 +141,9 @@ class ChangelogFormatter
                     $wrappedLines = $this->wrapText($formattedChange, $maxWidth - 4);
                     foreach ($wrappedLines as $idx => $line) {
                         if ($idx === 0) {
-                            $lines[] = '  ' . $this->green('•') . ' ' . $line;
+                            $lines[] = '  '.$this->green('•').' '.$line;
                         } else {
-                            $lines[] = '    ' . $line;
+                            $lines[] = '    '.$line;
                         }
                     }
                 }
@@ -156,7 +151,7 @@ class ChangelogFormatter
 
             // Fixes
             $fixes = $release->getFixes();
-            if (!empty($fixes)) {
+            if (! empty($fixes)) {
                 $lines[] = '';
                 $lines[] = $this->blue($this->bold('Fixes:'));
                 foreach ($fixes as $fix) {
@@ -165,9 +160,9 @@ class ChangelogFormatter
                     $wrappedLines = $this->wrapText($formattedFix, $maxWidth - 4);
                     foreach ($wrappedLines as $idx => $line) {
                         if ($idx === 0) {
-                            $lines[] = '  ' . $this->blue('•') . ' ' . $line;
+                            $lines[] = '  '.$this->blue('•').' '.$line;
                         } else {
-                            $lines[] = '    ' . $line;
+                            $lines[] = '    '.$line;
                         }
                     }
                 }
@@ -175,7 +170,7 @@ class ChangelogFormatter
 
             // Deprecated
             $deprecated = $release->getDeprecated();
-            if (!empty($deprecated)) {
+            if (! empty($deprecated)) {
                 $lines[] = '';
                 $lines[] = $this->yellow($this->bold('Deprecated:'));
                 foreach ($deprecated as $item) {
@@ -184,9 +179,9 @@ class ChangelogFormatter
                     $wrappedLines = $this->wrapText($formattedItem, $maxWidth - 4);
                     foreach ($wrappedLines as $idx => $line) {
                         if ($idx === 0) {
-                            $lines[] = '  ' . $this->yellow('•') . ' ' . $line;
+                            $lines[] = '  '.$this->yellow('•').' '.$line;
                         } else {
-                            $lines[] = '    ' . $line;
+                            $lines[] = '    '.$line;
                         }
                     }
                 }
@@ -194,7 +189,7 @@ class ChangelogFormatter
 
             // Removed
             $removed = $release->getRemoved();
-            if (!empty($removed)) {
+            if (! empty($removed)) {
                 $lines[] = '';
                 $lines[] = $this->red($this->bold('Removed:'));
                 foreach ($removed as $item) {
@@ -203,9 +198,9 @@ class ChangelogFormatter
                     $wrappedLines = $this->wrapText($formattedItem, $maxWidth - 4);
                     foreach ($wrappedLines as $idx => $line) {
                         if ($idx === 0) {
-                            $lines[] = '  ' . $this->red('•') . ' ' . $line;
+                            $lines[] = '  '.$this->red('•').' '.$line;
                         } else {
-                            $lines[] = '    ' . $line;
+                            $lines[] = '    '.$line;
                         }
                     }
                 }
@@ -213,7 +208,7 @@ class ChangelogFormatter
 
             // Security
             $security = $release->getSecurity();
-            if (!empty($security)) {
+            if (! empty($security)) {
                 $lines[] = '';
                 $lines[] = $this->magenta($this->bold('Security:'));
                 foreach ($security as $item) {
@@ -222,9 +217,9 @@ class ChangelogFormatter
                     $wrappedLines = $this->wrapText($formattedItem, $maxWidth - 4);
                     foreach ($wrappedLines as $idx => $line) {
                         if ($idx === 0) {
-                            $lines[] = '  ' . $this->magenta('•') . ' ' . $line;
+                            $lines[] = '  '.$this->magenta('•').' '.$line;
                         } else {
-                            $lines[] = '    ' . $line;
+                            $lines[] = '    '.$line;
                         }
                     }
                 }
@@ -240,8 +235,6 @@ class ChangelogFormatter
     /**
      * Format release notes in summary mode (all releases combined).
      *
-     * @param ReleaseNotesCollection $collection
-     * @param int $maxWidth
      * @return array<int, string>
      */
     private function formatSummary(ReleaseNotesCollection $collection, int $maxWidth): array
@@ -267,7 +260,7 @@ class ChangelogFormatter
         // If any release is unstructured, show all bullet points in a flat list
         if ($collection->hasUnstructuredReleases()) {
             $allBulletPoints = $collection->getAllBulletPoints();
-            if (!empty($allBulletPoints)) {
+            if (! empty($allBulletPoints)) {
                 $lines[] = $this->green($this->bold('Changes:'));
                 foreach ($allBulletPoints as $bulletPoint) {
                     // Format links before wrapping
@@ -275,21 +268,22 @@ class ChangelogFormatter
                     $wrappedLines = $this->wrapText($formattedBulletPoint, $maxWidth - 4);
                     foreach ($wrappedLines as $idx => $line) {
                         if ($idx === 0) {
-                            $lines[] = '  ' . $this->green('•') . ' ' . $line;
+                            $lines[] = '  '.$this->green('•').' '.$line;
                         } else {
-                            $lines[] = '    ' . $line;
+                            $lines[] = '    '.$line;
                         }
                     }
                 }
                 $lines[] = '';
             }
+
             return $lines;
         }
 
         // All releases are structured - show categorized sections
         // Breaking changes
         $breakingChanges = $collection->getBreakingChanges();
-        if (!empty($breakingChanges)) {
+        if (! empty($breakingChanges)) {
             $lines[] = $this->red($this->bold('Breaking Changes:'));
             foreach ($breakingChanges as $change) {
                 // Format links before wrapping
@@ -297,9 +291,9 @@ class ChangelogFormatter
                 $wrappedLines = $this->wrapText($formattedChange, $maxWidth - 4);
                 foreach ($wrappedLines as $idx => $line) {
                     if ($idx === 0) {
-                        $lines[] = '  ' . $this->red('•') . ' ' . $line;
+                        $lines[] = '  '.$this->red('•').' '.$line;
                     } else {
-                        $lines[] = '    ' . $line;
+                        $lines[] = '    '.$line;
                     }
                 }
             }
@@ -308,7 +302,7 @@ class ChangelogFormatter
 
         // Changes
         $changes = $collection->getChanges();
-        if (!empty($changes)) {
+        if (! empty($changes)) {
             $lines[] = $this->green($this->bold('Changes:'));
             foreach ($changes as $change) {
                 // Format links before wrapping
@@ -316,9 +310,9 @@ class ChangelogFormatter
                 $wrappedLines = $this->wrapText($formattedChange, $maxWidth - 4);
                 foreach ($wrappedLines as $idx => $line) {
                     if ($idx === 0) {
-                        $lines[] = '  ' . $this->green('•') . ' ' . $line;
+                        $lines[] = '  '.$this->green('•').' '.$line;
                     } else {
-                        $lines[] = '    ' . $line;
+                        $lines[] = '    '.$line;
                     }
                 }
             }
@@ -327,7 +321,7 @@ class ChangelogFormatter
 
         // Fixes
         $fixes = $collection->getFixes();
-        if (!empty($fixes)) {
+        if (! empty($fixes)) {
             $lines[] = $this->blue($this->bold('Fixes:'));
             foreach ($fixes as $fix) {
                 // Format links before wrapping
@@ -335,9 +329,9 @@ class ChangelogFormatter
                 $wrappedLines = $this->wrapText($formattedFix, $maxWidth - 4);
                 foreach ($wrappedLines as $idx => $line) {
                     if ($idx === 0) {
-                        $lines[] = '  ' . $this->blue('•') . ' ' . $line;
+                        $lines[] = '  '.$this->blue('•').' '.$line;
                     } else {
-                        $lines[] = '    ' . $line;
+                        $lines[] = '    '.$line;
                     }
                 }
             }
@@ -346,7 +340,7 @@ class ChangelogFormatter
 
         // Deprecated
         $deprecated = $collection->getDeprecated();
-        if (!empty($deprecated)) {
+        if (! empty($deprecated)) {
             $lines[] = $this->yellow($this->bold('Deprecated:'));
             foreach ($deprecated as $item) {
                 // Format links before wrapping
@@ -354,9 +348,9 @@ class ChangelogFormatter
                 $wrappedLines = $this->wrapText($formattedItem, $maxWidth - 4);
                 foreach ($wrappedLines as $idx => $line) {
                     if ($idx === 0) {
-                        $lines[] = '  ' . $this->yellow('•') . ' ' . $line;
+                        $lines[] = '  '.$this->yellow('•').' '.$line;
                     } else {
-                        $lines[] = '    ' . $line;
+                        $lines[] = '    '.$line;
                     }
                 }
             }
@@ -365,7 +359,7 @@ class ChangelogFormatter
 
         // Removed
         $removed = $collection->getRemoved();
-        if (!empty($removed)) {
+        if (! empty($removed)) {
             $lines[] = $this->red($this->bold('Removed:'));
             foreach ($removed as $item) {
                 // Format links before wrapping
@@ -373,9 +367,9 @@ class ChangelogFormatter
                 $wrappedLines = $this->wrapText($formattedItem, $maxWidth - 4);
                 foreach ($wrappedLines as $idx => $line) {
                     if ($idx === 0) {
-                        $lines[] = '  ' . $this->red('•') . ' ' . $line;
+                        $lines[] = '  '.$this->red('•').' '.$line;
                     } else {
-                        $lines[] = '    ' . $line;
+                        $lines[] = '    '.$line;
                     }
                 }
             }
@@ -384,7 +378,7 @@ class ChangelogFormatter
 
         // Security
         $security = $collection->getSecurity();
-        if (!empty($security)) {
+        if (! empty($security)) {
             $lines[] = $this->magenta($this->bold('Security:'));
             foreach ($security as $item) {
                 // Format links before wrapping
@@ -392,9 +386,9 @@ class ChangelogFormatter
                 $wrappedLines = $this->wrapText($formattedItem, $maxWidth - 4);
                 foreach ($wrappedLines as $idx => $line) {
                     if ($idx === 0) {
-                        $lines[] = '  ' . $this->magenta('•') . ' ' . $line;
+                        $lines[] = '  '.$this->magenta('•').' '.$line;
                     } else {
-                        $lines[] = '    ' . $line;
+                        $lines[] = '    '.$line;
                     }
                 }
             }
@@ -432,6 +426,7 @@ class ChangelogFormatter
     private function visibleLength(string $text): int
     {
         $stripped = $this->stripAnsiCodes($text);
+
         return mb_strwidth($stripped);
     }
 
@@ -441,8 +436,8 @@ class ChangelogFormatter
      * This method properly handles text that may contain ANSI escape sequences
      * by measuring only the visible characters when determining line breaks.
      *
-     * @param string $text Text to wrap (may contain ANSI codes)
-     * @param int $maxWidth Maximum visible width for each line
+     * @param  string  $text  Text to wrap (may contain ANSI codes)
+     * @param  int  $maxWidth  Maximum visible width for each line
      * @return array<int, string> Array of wrapped lines with ANSI codes preserved
      */
     private function wrapText(string $text, int $maxWidth): array
@@ -458,6 +453,7 @@ class ChangelogFormatter
             // Preserve empty lines
             if (empty(trim($this->stripAnsiCodes($paragraph)))) {
                 $lines[] = '';
+
                 continue;
             }
 
@@ -467,7 +463,7 @@ class ChangelogFormatter
 
             foreach ($words as $word) {
                 // Build test line
-                $testLine = $currentLine === '' ? $word : $currentLine . ' ' . $word;
+                $testLine = $currentLine === '' ? $word : $currentLine.' '.$word;
 
                 // Check visible length (excluding ANSI codes)
                 if ($this->visibleLength($testLine) <= $maxWidth) {
@@ -498,8 +494,8 @@ class ChangelogFormatter
      * Uses OSC 8 escape codes for terminal hyperlink support.
      * The display text is styled with dim color.
      *
-     * @param string $url The full URL to format
-     * @param int $maxWidth Maximum visible width for the URL text
+     * @param  string  $url  The full URL to format
+     * @param  int  $maxWidth  Maximum visible width for the URL text
      * @return string OSC 8 formatted clickable URL with dim styling, truncated if necessary
      */
     private function formatClickableUrl(string $url, int $maxWidth): string
@@ -528,7 +524,7 @@ class ChangelogFormatter
                 $currentWidth += $charWidth;
             }
 
-            $displayText = $truncated . '…';
+            $displayText = $truncated.'…';
         }
 
         // Apply dim styling to display text and wrap in OSC 8 hyperlink codes
@@ -542,7 +538,7 @@ class ChangelogFormatter
      * GitHub PR/issue URLs are displayed in compact format (#123).
      * Note: Links are not clickable in TUI mode, only shortened for readability.
      *
-     * @param string $text Text containing potential markdown links and URLs
+     * @param  string  $text  Text containing potential markdown links and URLs
      * @return string Text with shortened URLs
      */
     private function formatTextWithLinks(string $text): string

--- a/src/Outputs/Tui/MarkdownToConsole.php
+++ b/src/Outputs/Tui/MarkdownToConsole.php
@@ -11,9 +11,7 @@ class MarkdownToConsole
     use Colors;
 
     public function __construct(
-    ) {
-
-    }
+    ) {}
 
     public function parseMarkdown($markdown): array
     {
@@ -49,7 +47,6 @@ class MarkdownToConsole
             fn ($matches) => $this->bgBlue($matches[1]),
             $markdown
         );
-
 
         // // Convert bold
         // $markdown = preg_replace('/\*\*(.*?)\*\*/', "\033[1m$1\033[0m", $markdown);

--- a/src/Outputs/Tui/MultipleScrolling.php
+++ b/src/Outputs/Tui/MultipleScrolling.php
@@ -54,9 +54,6 @@ trait MultipleScrolling
 
     /**
      * Initialize scrolling for the given key.
-     *
-     * @param  string  $key
-     * @param  int|null  $highlighted
      */
     protected function initializeMultipleScrolling(string $key, ?int $highlighted = null): void
     {
@@ -70,8 +67,6 @@ trait MultipleScrolling
      * Reduce the scroll property to fit the terminal height for the given key.
      *
      * Assumes that $this->scroll[$key] has already been set.
-     *
-     * @param  string  $key
      */
     protected function reduceScrollingToFitTerminal(string $key): void
     {
@@ -82,9 +77,6 @@ trait MultipleScrolling
 
     /**
      * Highlight the given index for the specified scroll bar key.
-     *
-     * @param  string  $key
-     * @param  int|null  $index
      */
     protected function highlight(string $key, ?int $index): void
     {
@@ -103,10 +95,6 @@ trait MultipleScrolling
 
     /**
      * Highlight the previous entry for the given key, or wrap around to the last entry.
-     *
-     * @param  string  $key
-     * @param  int  $total
-     * @param  bool  $allowNull
      */
     protected function highlightPrevious(string $key, int $total, bool $allowNull = false): void
     {
@@ -125,10 +113,6 @@ trait MultipleScrolling
 
     /**
      * Highlight the next entry for the given key, or wrap around to the first entry.
-     *
-     * @param  string  $key
-     * @param  int  $total
-     * @param  bool  $allowNull
      */
     protected function highlightNext(string $key, int $total, bool $allowNull = false): void
     {
@@ -145,9 +129,6 @@ trait MultipleScrolling
 
     /**
      * Center the highlighted option for the given key.
-     *
-     * @param  string  $key
-     * @param  int  $total
      */
     protected function scrollToHighlighted(string $key, int $total): void
     {

--- a/src/Outputs/Tui/TerminalUI.php
+++ b/src/Outputs/Tui/TerminalUI.php
@@ -19,12 +19,14 @@ use Whatsdiff\Services\GitRepository;
 
 class TerminalUI extends Prompt
 {
-    use RegistersThemes;
     use CreatesAnAltScreen;
     use MultipleScrolling;
+    use RegistersThemes;
 
     public array $packages;
+
     public ?int $selected = null;
+
     public bool $summaryMode = false;
 
     private array $changelogCache = [];
@@ -148,7 +150,7 @@ class TerminalUI extends Prompt
         );
 
         // Format the changelog
-        $formatter = new ChangelogFormatter();
+        $formatter = new ChangelogFormatter;
 
         return $formatter->format($changelog, $this->summaryMode, $rightPaneWidth);
     }
@@ -214,7 +216,6 @@ class TerminalUI extends Prompt
             return null;
         }
     }
-
 
     public function rightPaneVisible()
     {

--- a/src/Outputs/Tui/TerminalUIRenderer.php
+++ b/src/Outputs/Tui/TerminalUIRenderer.php
@@ -20,15 +20,19 @@ class TerminalUIRenderer extends Renderer implements Scrolling
     use Aligns;
     use DrawsHotkeys;
     use DrawsScrollbars;
-    use InteractsWithStrings;
     use HasMinimumDimensions;
+    use InteractsWithStrings;
 
     public int $rightPaneWidth;
+
     public int $sideBarWidth;
+
     protected int $uiWidth;
+
     protected int $uiHeight;
 
     protected TerminalUI $terminalUI;
+
     protected int $contentHeight;
 
     public function __invoke(TerminalUI $prompt): static
@@ -68,7 +72,6 @@ class TerminalUIRenderer extends Renderer implements Scrolling
         $this->sideBarWidth = intval(ceil($this->uiWidth / 3));
         $this->rightPaneWidth = $this->uiWidth - $this->sideBarWidth;
 
-
         // Render the sidebar and the content
         $sidebar = $this->layoutSidebar();
         $content = $this->rightPaneContent();
@@ -85,7 +88,6 @@ class TerminalUIRenderer extends Renderer implements Scrolling
         $this->renderBottom($this->uiHeight, $footer);
 
     }
-
 
     protected function renderBottom(int $height, $bottom)
     {
@@ -122,7 +124,7 @@ class TerminalUIRenderer extends Renderer implements Scrolling
 
         // Calculate spacing
         $leftLength = 6 + mb_strwidth($leftText); // 6 for the logo and spaces
-        $rightLength = mb_strwidth(' '.$githubText.' / '.$websiteText. '');
+        $rightLength = mb_strwidth(' '.$githubText.' / '.$websiteText.'');
         $spacing = max(1, $this->uiWidth - 2 - $leftLength - $rightLength);
 
         // White background with black text - classic inverse terminal look
@@ -212,9 +214,7 @@ class TerminalUIRenderer extends Renderer implements Scrolling
                 // $name = $icon.' '.$name;
                 $label = $name;
 
-
                 $index = array_search($key, array_keys($this->terminalUI->sidebarPackages()));
-
 
                 // Cursor represented by an arrow
                 // $name = $this->terminalUI->highlighted === $index ? '➤'.$name : ' '.$name;
@@ -224,7 +224,6 @@ class TerminalUIRenderer extends Renderer implements Scrolling
                 $innerWidth = $this->sideBarWidth - 1;
                 $label = $this->truncate($label, $innerWidth);
                 $label = $this->pad($label, $innerWidth + 1, ' ');
-
 
                 // If nothing is selected and the cursor is on it, highlight it
                 if ($this->terminalUI->selected === null && $this->terminalUI->getHighlighted('sidebar') === $index) {
@@ -309,5 +308,4 @@ class TerminalUIRenderer extends Renderer implements Scrolling
     {
         return "\e[107m{$string}\e[49m";
     }
-
 }

--- a/src/Services/AnalyzerRegistry.php
+++ b/src/Services/AnalyzerRegistry.php
@@ -29,14 +29,13 @@ class AnalyzerRegistry
 
     public function __construct(
         private readonly ContainerInterface $container
-    ) {
-    }
+    ) {}
 
     /**
      * Register an analyzer for a specific package manager type.
      *
-     * @param PackageManagerType $type Package manager type
-     * @param string $analyzerClass Fully qualified analyzer class name
+     * @param  PackageManagerType  $type  Package manager type
+     * @param  string  $analyzerClass  Fully qualified analyzer class name
      * @return self For method chaining
      */
     public function register(PackageManagerType $type, string $analyzerClass): self
@@ -51,8 +50,9 @@ class AnalyzerRegistry
      *
      * Lazy loads the analyzer on first access and caches it for subsequent calls.
      *
-     * @param PackageManagerType $type Package manager type
+     * @param  PackageManagerType  $type  Package manager type
      * @return AnalyzerInterface The analyzer instance
+     *
      * @throws \RuntimeException If no analyzer is registered for the type
      */
     public function get(PackageManagerType $type): AnalyzerInterface
@@ -86,7 +86,7 @@ class AnalyzerRegistry
     /**
      * Check if an analyzer is registered for the specified type.
      *
-     * @param PackageManagerType $type Package manager type
+     * @param  PackageManagerType  $type  Package manager type
      * @return bool True if an analyzer is registered
      */
     public function has(PackageManagerType $type): bool

--- a/src/Services/CacheService.php
+++ b/src/Services/CacheService.php
@@ -11,14 +11,17 @@ use Symfony\Component\Filesystem\Filesystem;
 class CacheService
 {
     private CacheItemPoolInterface $cache;
+
     private ConfigService $config;
+
     private Filesystem $filesystem;
+
     private bool $forceDisabled = false;
 
     public function __construct(ConfigService $config, ?string $cacheDir = null)
     {
         $this->config = $config;
-        $this->filesystem = new Filesystem();
+        $this->filesystem = new Filesystem;
 
         $cacheDirectory = $cacheDir ?? $this->getDefaultCacheDir();
         $this->ensureCacheDirectoryExists($cacheDirectory);
@@ -32,7 +35,7 @@ class CacheService
 
     public function get(string $key, callable $callback): mixed
     {
-        if (!$this->isCacheEnabled()) {
+        if (! $this->isCacheEnabled()) {
             return $callback();
         }
 
@@ -55,7 +58,7 @@ class CacheService
 
     public function set(string $key, mixed $value, ?int $ttl = null): void
     {
-        if (!$this->isCacheEnabled()) {
+        if (! $this->isCacheEnabled()) {
             return;
         }
 
@@ -154,16 +157,16 @@ class CacheService
     private function getDefaultCacheDir(): string
     {
         $home = getenv('HOME') ?: getenv('USERPROFILE');
-        if (!$home) {
+        if (! $home) {
             throw new \RuntimeException('Cannot determine home directory');
         }
 
-        return $home . DIRECTORY_SEPARATOR . '.whatsdiff' . DIRECTORY_SEPARATOR . 'cache';
+        return $home.DIRECTORY_SEPARATOR.'.whatsdiff'.DIRECTORY_SEPARATOR.'cache';
     }
 
     private function ensureCacheDirectoryExists(string $directory): void
     {
-        if (!$this->filesystem->exists($directory)) {
+        if (! $this->filesystem->exists($directory)) {
             $this->filesystem->mkdir($directory, 0755);
         }
     }

--- a/src/Services/ConfigService.php
+++ b/src/Services/ConfigService.php
@@ -11,8 +11,11 @@ use Symfony\Component\Yaml\Yaml;
 class ConfigService
 {
     private Filesystem $filesystem;
+
     private string $configPath;
+
     private array $config = [];
+
     private array $defaults = [
         'cache' => [
             'enabled' => true,
@@ -26,7 +29,7 @@ class ConfigService
 
     public function __construct(?string $configPath = null)
     {
-        $this->filesystem = new Filesystem();
+        $this->filesystem = new Filesystem;
         $this->configPath = $configPath ?? $this->getDefaultConfigPath();
         $this->loadConfig();
     }
@@ -62,11 +65,11 @@ class ConfigService
     private function getDefaultConfigPath(): string
     {
         $home = getenv('HOME') ?: getenv('USERPROFILE');
-        if (!$home) {
+        if (! $home) {
             throw new \RuntimeException('Cannot determine home directory');
         }
 
-        return $home . DIRECTORY_SEPARATOR . '.whatsdiff' . DIRECTORY_SEPARATOR . 'config.yaml';
+        return $home.DIRECTORY_SEPARATOR.'.whatsdiff'.DIRECTORY_SEPARATOR.'config.yaml';
     }
 
     private function loadConfig(): void
@@ -92,13 +95,12 @@ class ConfigService
     private function ensureConfigExists(): void
     {
         $dir = dirname($this->configPath);
-        if (!$this->filesystem->exists($dir)) {
+        if (! $this->filesystem->exists($dir)) {
             $this->filesystem->mkdir($dir, 0755);
         }
 
-        if (!$this->filesystem->exists($this->configPath)) {
+        if (! $this->filesystem->exists($this->configPath)) {
             $this->filesystem->dumpFile($this->configPath, Yaml::dump($this->defaults, 4, 2));
         }
     }
-
 }

--- a/src/Services/DiffCalculator.php
+++ b/src/Services/DiffCalculator.php
@@ -21,13 +21,18 @@ class DiffCalculator
     private GitRepository $git;
 
     private Collection $dependencyFiles;
+
     private array $dependencyTypes;
 
     // Fluent interface state
     private ?string $fromCommit = null;
+
     private ?string $toCommit = null;
+
     private bool $ignoreLast = false;
+
     private bool $skipReleaseCount = false;
+
     private ?DiffResult $diffResult = null;
 
     public function __construct(
@@ -214,12 +219,12 @@ class DiffCalculator
         $this->diffResult = new DiffResult($diffs, $recentlyUpdated);
     }
 
-
     /**
      * Calculate diff between commits with progress reporting
      * Yields individual PackageChange objects as they're processed
      *
      * @return \Generator<PackageChange>
+     *
      * @noinspection PhpInconsistentReturnPointsInspection
      */
     private function calculateDiffBetweenCommitsWithProgress(
@@ -275,7 +280,6 @@ class DiffCalculator
         return $dependencyDiff;
     }
 
-
     private function initializeDependencyFiles(bool $ignoreLast): void
     {
         // Initialize dependency files structure if not already done
@@ -306,7 +310,6 @@ class DiffCalculator
         });
     }
 
-
     private function getCommitHashToCompare(array $commitLogs, bool $recentlyUpdated): array
     {
         $last = $recentlyUpdated ? null : $commitLogs[0];
@@ -316,12 +319,10 @@ class DiffCalculator
         return [$last, $previous];
     }
 
-
     private function calculatePackageDiff(PackageManagerType $type, string $last, ?string $previous): array
     {
         return $this->analyzerRegistry->get($type)->calculateDiff($last, $previous);
     }
-
 
     /**
      * Convert package diffs to PackageChange objects with progress reporting
@@ -392,7 +393,7 @@ class DiffCalculator
     /**
      * Filter advisories to only those fixed by updating from one version to another.
      *
-     * @param array<SecurityAdvisory> $advisories
+     * @param  array<SecurityAdvisory>  $advisories
      * @return array<SecurityAdvisory>
      */
     private function filterFixedAdvisories(array $advisories, string $from, string $to): array

--- a/src/Services/GitRepository.php
+++ b/src/Services/GitRepository.php
@@ -7,14 +7,18 @@ namespace Whatsdiff\Services;
 class GitRepository
 {
     private ?string $gitRoot = null;
+
     private ?string $currentDir = null;
+
     private ?string $relativeCurrentDir = null;
+
     private ProcessService $processService;
+
     private bool $initialized = false;
 
     public function __construct(?ProcessService $processService = null)
     {
-        $this->processService = $processService ?? new ProcessService();
+        $this->processService = $processService ?? new ProcessService;
     }
 
     /**
@@ -31,7 +35,7 @@ class GitRepository
 
         $process = $this->processService->git(['rev-parse', '--show-toplevel']);
 
-        if (!$process->isSuccessful() || empty(trim($process->getOutput()))) {
+        if (! $process->isSuccessful() || empty(trim($process->getOutput()))) {
             throw new \RuntimeException('Not in a git repository or git command failed');
         }
 
@@ -85,8 +89,7 @@ class GitRepository
 
         $process = $this->processService->git($args, $this->gitRoot);
 
-
-        if (!$process->isSuccessful() || empty(trim($process->getOutput()))) {
+        if (! $process->isSuccessful() || empty(trim($process->getOutput()))) {
             return [];
         }
 
@@ -101,7 +104,7 @@ class GitRepository
 
         $process = $this->processService->git($args, $this->gitRoot);
 
-        if (!$process->isSuccessful() || empty(trim($process->getOutput()))) {
+        if (! $process->isSuccessful() || empty(trim($process->getOutput()))) {
             return [];
         }
 
@@ -114,7 +117,7 @@ class GitRepository
 
         $process = $this->processService->git(['status', '--porcelain'], $this->gitRoot);
 
-        if (!$process->isSuccessful() || empty(trim($process->getOutput()))) {
+        if (! $process->isSuccessful() || empty(trim($process->getOutput()))) {
             return false;
         }
 
@@ -123,11 +126,12 @@ class GitRepository
             ->filter()
             ->mapWithKeys(function ($line) {
                 $parts = array_values(array_filter(explode(' ', $line)));
+
                 return isset($parts[1]) ? [$parts[1] => $parts[0]] : [];
             });
 
         // If the file exists and is not in the list of untracked files
-        if (!empty($this->relativeCurrentDir) && file_exists($filename) && !$status->has($filename)) {
+        if (! empty($this->relativeCurrentDir) && file_exists($filename) && ! $status->has($filename)) {
             return true; // Created
         }
 
@@ -144,7 +148,7 @@ class GitRepository
         $this->ensureInitialized();
 
         $process = $this->processService->git(
-            ['show', $commitHash . ':' . $filename],
+            ['show', $commitHash.':'.$filename],
             $this->gitRoot
         );
 

--- a/src/Services/GithubAuthService.php
+++ b/src/Services/GithubAuthService.php
@@ -15,6 +15,7 @@ namespace Whatsdiff\Services;
 class GithubAuthService
 {
     private ?string $cachedToken = null;
+
     private bool $tokenLoaded = false;
 
     /**
@@ -36,9 +37,10 @@ class GithubAuthService
 
         // Priority 1: GITHUB_TOKEN environment variable
         $envToken = getenv('GITHUB_TOKEN');
-        if ($envToken !== false && !empty($envToken)) {
+        if ($envToken !== false && ! empty($envToken)) {
             $this->cachedToken = $envToken;
             $this->tokenLoaded = true;
+
             return $this->cachedToken;
         }
 
@@ -47,21 +49,24 @@ class GithubAuthService
         if ($token !== null) {
             $this->cachedToken = $token;
             $this->tokenLoaded = true;
+
             return $this->cachedToken;
         }
 
         // Priority 4: COMPOSER_AUTH environment variable
         $composerAuth = getenv('COMPOSER_AUTH');
-        if ($composerAuth !== false && !empty($composerAuth)) {
+        if ($composerAuth !== false && ! empty($composerAuth)) {
             $authData = json_decode($composerAuth, true);
             if (is_array($authData) && isset($authData['github-oauth']['github.com'])) {
                 $this->cachedToken = $authData['github-oauth']['github.com'];
                 $this->tokenLoaded = true;
+
                 return $this->cachedToken;
             }
         }
 
         $this->tokenLoaded = true;
+
         return null;
     }
 
@@ -85,10 +90,10 @@ class GithubAuthService
     private function loadTokenFromAuthJson(): ?string
     {
         $currentDir = getcwd() ?: '';
-        $localAuthPath = $currentDir . DIRECTORY_SEPARATOR . 'auth.json';
+        $localAuthPath = $currentDir.DIRECTORY_SEPARATOR.'auth.json';
 
         $HOME = getenv('HOME') ?: getenv('USERPROFILE');
-        $globalAuthPath = $HOME . DIRECTORY_SEPARATOR . '.composer/auth.json';
+        $globalAuthPath = $HOME.DIRECTORY_SEPARATOR.'.composer/auth.json';
 
         // Check local auth.json first (higher priority)
         if (file_exists($localAuthPath)) {
@@ -112,7 +117,7 @@ class GithubAuthService
     /**
      * Extract GitHub OAuth token from an auth.json file.
      *
-     * @param string $filePath Path to the auth.json file
+     * @param  string  $filePath  Path to the auth.json file
      * @return string|null GitHub token or null if not found
      */
     private function extractTokenFromFile(string $filePath): ?string
@@ -123,13 +128,13 @@ class GithubAuthService
         }
 
         $authData = json_decode($content, true);
-        if (!is_array($authData)) {
+        if (! is_array($authData)) {
             return null;
         }
 
         if (isset($authData['github-oauth']['github.com'])) {
             $token = $authData['github-oauth']['github.com'];
-            if (is_string($token) && !empty($token)) {
+            if (is_string($token) && ! empty($token)) {
                 return $token;
             }
         }

--- a/src/Services/HttpService.php
+++ b/src/Services/HttpService.php
@@ -14,8 +14,11 @@ use Whatsdiff\Application;
 class HttpService
 {
     private CacheService $cache;
+
     private Client $client;
+
     private array $lastResponseHeaders = [];
+
     private GithubAuthService $githubAuth;
 
     public function __construct(CacheService $cache, GithubAuthService $githubAuth)
@@ -37,7 +40,7 @@ class HttpService
 
     public function get(string $url, array $options = []): string
     {
-        $cacheKey = 'http_' . $url;
+        $cacheKey = 'http_'.$url;
 
         return $this->cache->get($cacheKey, function () use ($url, $options) {
             return $this->fetchUrl($url, $options);
@@ -46,10 +49,11 @@ class HttpService
 
     public function getWithHeaders(string $url, array $options = []): array
     {
-        $cacheKey = 'http_with_headers_' . $url;
+        $cacheKey = 'http_with_headers_'.$url;
 
         return $this->cache->get($cacheKey, function () use ($url, $options) {
             $content = $this->fetchUrl($url, $options);
+
             return [
                 'body' => $content,
                 'headers' => $this->lastResponseHeaders,
@@ -68,7 +72,7 @@ class HttpService
         $guzzleOptions = [];
 
         // Set User-Agent
-        $userAgent = $options['user_agent'] ?? 'whatsdiff/' . Application::getVersionString();
+        $userAgent = $options['user_agent'] ?? 'whatsdiff/'.Application::getVersionString();
         $guzzleOptions['headers']['User-Agent'] = $userAgent;
 
         // Handle HTTP authentication if provided
@@ -87,10 +91,10 @@ class HttpService
         }
 
         // Automatically add GitHub authentication for api.github.com requests
-        if ($this->isGithubApiUrl($url) && !isset($guzzleOptions['headers']['Authorization'])) {
+        if ($this->isGithubApiUrl($url) && ! isset($guzzleOptions['headers']['Authorization'])) {
             $token = $this->githubAuth->getToken();
             if ($token !== null) {
-                $guzzleOptions['headers']['Authorization'] = 'Bearer ' . $token;
+                $guzzleOptions['headers']['Authorization'] = 'Bearer '.$token;
             }
         }
 
@@ -102,9 +106,9 @@ class HttpService
                 $statusCode = $response->getStatusCode();
                 throw new RuntimeException("HTTP request failed with status code: {$statusCode}");
             }
-            throw new RuntimeException('Failed to fetch URL: ' . $e->getMessage());
+            throw new RuntimeException('Failed to fetch URL: '.$e->getMessage());
         } catch (GuzzleException $e) {
-            throw new RuntimeException('Failed to fetch URL: ' . $e->getMessage());
+            throw new RuntimeException('Failed to fetch URL: '.$e->getMessage());
         }
 
         $statusCode = $response->getStatusCode();
@@ -121,7 +125,7 @@ class HttpService
         // Update cache duration based on headers
         $cacheDuration = $this->cache->getCacheDuration($this->lastResponseHeaders);
         if ($cacheDuration > 0) {
-            $cacheKey = 'http_' . $url;
+            $cacheKey = 'http_'.$url;
             $this->cache->set($cacheKey, $body, $cacheDuration);
         }
 
@@ -147,13 +151,13 @@ class HttpService
     /**
      * Check if a URL is a GitHub API URL.
      *
-     * @param string $url The URL to check
+     * @param  string  $url  The URL to check
      * @return bool True if the URL is a GitHub API URL
      */
     private function isGithubApiUrl(string $url): bool
     {
         $host = parse_url($url, PHP_URL_HOST);
+
         return $host === 'api.github.com';
     }
-
 }

--- a/src/Services/ProcessService.php
+++ b/src/Services/ProcessService.php
@@ -13,7 +13,7 @@ class ProcessService
 
     public function __construct()
     {
-        $this->executableFinder = new ExecutableFinder();
+        $this->executableFinder = new ExecutableFinder;
     }
 
     public function run(array $command, ?string $cwd = null, ?int $timeout = 60): Process
@@ -27,6 +27,7 @@ class ProcessService
     public function git(array $gitArgs, ?string $cwd = null): Process
     {
         $command = array_merge(['git'], $gitArgs);
+
         return $this->run($command, $cwd);
     }
 
@@ -34,11 +35,12 @@ class ProcessService
     {
         $phpBinary = $this->executableFinder->find('php');
 
-        if (!$phpBinary) {
+        if (! $phpBinary) {
             throw new \RuntimeException('PHP executable not found');
         }
 
         $command = array_merge([$phpBinary], $phpArgs);
+
         return $this->run($command, $cwd);
     }
 }

--- a/src/whatsdiff-mcp.php
+++ b/src/whatsdiff-mcp.php
@@ -48,5 +48,5 @@ $server = Server::make()
     ->build();
 
 // Create and start stdio transport
-$transport = new StdioServerTransport();
+$transport = new StdioServerTransport;
 $server->listen($transport);

--- a/src/whatsdiff.php
+++ b/src/whatsdiff.php
@@ -11,10 +11,10 @@ if (! class_exists('\Composer\InstalledVersions')) {
 
 // Set up error handling
 if (class_exists('\NunoMaduro\Collision\Provider')) {
-    (new \NunoMaduro\Collision\Provider())->register();
+    (new \NunoMaduro\Collision\Provider)->register();
 } else {
     error_reporting(0);
 }
 
-$application = new Application();
+$application = new Application;
 $application->run();

--- a/tests/Feature/AnalyseCommand/IncludeExcludeOptionsTest.php
+++ b/tests/Feature/AnalyseCommand/IncludeExcludeOptionsTest.php
@@ -18,8 +18,8 @@ it('includes only composer dependencies with --include=composer', function () {
     $packageLock = generatePackageLock(['lodash' => '4.17.20']);
 
     // Create initial commits
-    file_put_contents($this->tempDir . '/composer.lock', $composerLock);
-    file_put_contents($this->tempDir . '/package-lock.json', $packageLock);
+    file_put_contents($this->tempDir.'/composer.lock', $composerLock);
+    file_put_contents($this->tempDir.'/package-lock.json', $packageLock);
     runCommand('git add .');
     runCommand('git commit -m "Initial dependencies"');
     $firstCommit = trim(runCommand('git rev-parse HEAD'));
@@ -28,14 +28,14 @@ it('includes only composer dependencies with --include=composer', function () {
     $composerLock = generateComposerLock(['symfony/console' => 'v6.0.0']);
     $packageLock = generatePackageLock(['lodash' => '4.17.21']);
 
-    file_put_contents($this->tempDir . '/composer.lock', $composerLock);
-    file_put_contents($this->tempDir . '/package-lock.json', $packageLock);
+    file_put_contents($this->tempDir.'/composer.lock', $composerLock);
+    file_put_contents($this->tempDir.'/package-lock.json', $packageLock);
     runCommand('git add .');
     runCommand('git commit -m "Update dependencies"');
     $secondCommit = trim(runCommand('git rev-parse HEAD'));
 
     // Test with --include=composer
-    $process = runWhatsDiff(['analyse', '--from=' . $firstCommit, '--to=' . $secondCommit, '--include=composer'], $this->tempDir);
+    $process = runWhatsDiff(['analyse', '--from='.$firstCommit, '--to='.$secondCommit, '--include=composer'], $this->tempDir);
     expect($process->getExitCode())->toBe(Command::SUCCESS);
     expect($process->getOutput())->toContain('symfony/console'); // Should include Composer package
     expect($process->getOutput())->not->toContain('lodash'); // Should not include npm package
@@ -47,8 +47,8 @@ it('includes only npm dependencies with --include=npmjs', function () {
     $packageLock = generatePackageLock(['react' => '17.0.0']);
 
     // Create initial commits
-    file_put_contents($this->tempDir . '/composer.lock', $composerLock);
-    file_put_contents($this->tempDir . '/package-lock.json', $packageLock);
+    file_put_contents($this->tempDir.'/composer.lock', $composerLock);
+    file_put_contents($this->tempDir.'/package-lock.json', $packageLock);
     runCommand('git add .');
     runCommand('git commit -m "Initial dependencies"');
     $firstCommit = trim(runCommand('git rev-parse HEAD'));
@@ -57,14 +57,14 @@ it('includes only npm dependencies with --include=npmjs', function () {
     $composerLockUpdated = generateComposerLock(['laravel/framework' => 'v10.0.0']);
     $packageLockUpdated = generatePackageLock(['react' => '18.0.0']);
 
-    file_put_contents($this->tempDir . '/composer.lock', $composerLockUpdated);
-    file_put_contents($this->tempDir . '/package-lock.json', $packageLockUpdated);
+    file_put_contents($this->tempDir.'/composer.lock', $composerLockUpdated);
+    file_put_contents($this->tempDir.'/package-lock.json', $packageLockUpdated);
     runCommand('git add .');
     runCommand('git commit -m "Update dependencies"');
     $secondCommit = trim(runCommand('git rev-parse HEAD'));
 
     // Test with --include=npmjs
-    $process = runWhatsDiff(['analyse', '--from=' . $firstCommit, '--to=' . $secondCommit, '--include=npmjs'], $this->tempDir);
+    $process = runWhatsDiff(['analyse', '--from='.$firstCommit, '--to='.$secondCommit, '--include=npmjs'], $this->tempDir);
 
     expect($process->getExitCode())->toBe(Command::SUCCESS);
     expect($process->getOutput())->toContain('react'); // Should include npm package
@@ -77,8 +77,8 @@ it('excludes composer dependencies with --exclude=composer', function () {
     $packageLock = generatePackageLock(['axios' => '0.27.0']);
 
     // Create initial commits
-    file_put_contents($this->tempDir . '/composer.lock', $composerLock);
-    file_put_contents($this->tempDir . '/package-lock.json', $packageLock);
+    file_put_contents($this->tempDir.'/composer.lock', $composerLock);
+    file_put_contents($this->tempDir.'/package-lock.json', $packageLock);
     runCommand('git add .');
     runCommand('git commit -m "Initial dependencies"');
     $firstCommit = trim(runCommand('git rev-parse HEAD'));
@@ -87,14 +87,14 @@ it('excludes composer dependencies with --exclude=composer', function () {
     $composerLockUpdated = generateComposerLock(['monolog/monolog' => '3.0.0']);
     $packageLockUpdated = generatePackageLock(['axios' => '1.0.0']);
 
-    file_put_contents($this->tempDir . '/composer.lock', $composerLockUpdated);
-    file_put_contents($this->tempDir . '/package-lock.json', $packageLockUpdated);
+    file_put_contents($this->tempDir.'/composer.lock', $composerLockUpdated);
+    file_put_contents($this->tempDir.'/package-lock.json', $packageLockUpdated);
     runCommand('git add .');
     runCommand('git commit -m "Update dependencies"');
     $secondCommit = trim(runCommand('git rev-parse HEAD'));
 
     // Test with --exclude=composer
-    $process = runWhatsDiff(['analyse', '--from=' . $firstCommit, '--to=' . $secondCommit, '--exclude=composer'], $this->tempDir);
+    $process = runWhatsDiff(['analyse', '--from='.$firstCommit, '--to='.$secondCommit, '--exclude=composer'], $this->tempDir);
 
     expect($process->getExitCode())->toBe(Command::SUCCESS);
     expect($process->getOutput())->toContain('axios'); // Should include npm package
@@ -120,7 +120,7 @@ it('supports npm alias with --include=npm', function () {
     ];
 
     // Create initial commit
-    file_put_contents($this->tempDir . '/package-lock.json', json_encode($packageLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/package-lock.json', json_encode($packageLock, JSON_PRETTY_PRINT));
     runCommand('git add .');
     runCommand('git commit -m "Initial npm dependencies"');
     $firstCommit = trim(runCommand('git rev-parse HEAD'));
@@ -128,13 +128,13 @@ it('supports npm alias with --include=npm', function () {
     // Update npm package
     $packageLock['packages']['node_modules/vue']['version'] = '3.3.0';
 
-    file_put_contents($this->tempDir . '/package-lock.json', json_encode($packageLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/package-lock.json', json_encode($packageLock, JSON_PRETTY_PRINT));
     runCommand('git add .');
     runCommand('git commit -m "Update vue"');
     $secondCommit = trim(runCommand('git rev-parse HEAD'));
 
     // Test with --include=npm (alias for npmjs)
-    $process = runWhatsDiff(['analyse', '--from=' . $firstCommit, '--to=' . $secondCommit, '--include=npm'], $this->tempDir);
+    $process = runWhatsDiff(['analyse', '--from='.$firstCommit, '--to='.$secondCommit, '--include=npm'], $this->tempDir);
 
     expect($process->getExitCode())->toBe(Command::SUCCESS);
     expect($process->getOutput())->toContain('vue'); // Should include npm package
@@ -142,7 +142,7 @@ it('supports npm alias with --include=npm', function () {
 
 it('fails when both --include and --exclude are provided', function () {
     // Create minimal git repository
-    file_put_contents($this->tempDir . '/composer.lock', '{}');
+    file_put_contents($this->tempDir.'/composer.lock', '{}');
     runCommand('git add composer.lock');
     runCommand('git commit -m "Initial commit"');
 
@@ -150,12 +150,12 @@ it('fails when both --include and --exclude are provided', function () {
     $process = runWhatsDiff(['analyse', '--include=composer', '--exclude=npmjs'], $this->tempDir);
 
     expect($process->getExitCode())->toBe(Command::FAILURE);
-    expect($process->getOutput() . $process->getErrorOutput())->toContain('Cannot use both --include and --exclude options');
+    expect($process->getOutput().$process->getErrorOutput())->toContain('Cannot use both --include and --exclude options');
 });
 
 it('fails with invalid package manager type', function () {
     // Create minimal git repository
-    file_put_contents($this->tempDir . '/composer.lock', '{}');
+    file_put_contents($this->tempDir.'/composer.lock', '{}');
     runCommand('git add composer.lock');
     runCommand('git commit -m "Initial commit"');
 
@@ -163,6 +163,6 @@ it('fails with invalid package manager type', function () {
     $process = runWhatsDiff(['analyse', '--include=invalid'], $this->tempDir);
 
     expect($process->getExitCode())->toBe(Command::FAILURE);
-    expect($process->getOutput() . $process->getErrorOutput())->toContain('Invalid package manager type');
-    expect($process->getOutput() . $process->getErrorOutput())->toContain('Valid types: composer, npmjs');
+    expect($process->getOutput().$process->getErrorOutput())->toContain('Invalid package manager type');
+    expect($process->getOutput().$process->getErrorOutput())->toContain('Valid types: composer, npmjs');
 });

--- a/tests/Feature/AnalyseCommand/PrivateComposerPackageTest.php
+++ b/tests/Feature/AnalyseCommand/PrivateComposerPackageTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
     $this->tempDir = initTempDirectory();
 
     // Create a mock HttpService that returns fake package data
-    $this->mockHttpService = new MockHttpService();
+    $this->mockHttpService = new MockHttpService;
 });
 
 afterEach(function () {
@@ -97,7 +97,7 @@ it('handles private composer packages with authentication', function () {
 
     try {
         // Create container with autowiring and test service provider that mocks only HttpService
-        $container = new Container();
+        $container = new Container;
         $container->delegate(new ReflectionContainer(true));
         (new TestServiceProvider($this->mockHttpService))->register($container);
 
@@ -159,7 +159,7 @@ it('handles private packages without authentication gracefully', function () {
     chdir($this->tempDir);
 
     try {
-        $container = new Container();
+        $container = new Container;
         $container->delegate(new ReflectionContainer(true));
         (new TestServiceProvider($this->mockHttpService))->register($container);
 
@@ -202,7 +202,7 @@ it('prioritizes local auth.json over global auth.json', function () {
     ]);
 
     // Configure mock HTTP service to verify auth headers are passed correctly
-    $authAwareHttpService = new MockHttpService();
+    $authAwareHttpService = new MockHttpService;
     $authAwareHttpService->setResponse('https://composer.fluxui.dev/p2/livewire/flux-pro.json', $mockResponse);
 
     // Create local auth.json that should be prioritized
@@ -234,7 +234,7 @@ it('prioritizes local auth.json over global auth.json', function () {
     chdir($this->tempDir);
 
     try {
-        $container = new Container();
+        $container = new Container;
         $container->delegate(new ReflectionContainer(true));
         (new TestServiceProvider($authAwareHttpService))->register($container);
 

--- a/tests/Feature/DefaultCommandTest.php
+++ b/tests/Feature/DefaultCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 beforeEach(function () {
     $this->tempDir = initTempDirectory();
 });
@@ -29,7 +28,7 @@ test('list command works', function () {
     $process = runWhatsDiff(['list']);
 
     expect($process->getExitCode())->toBe(0);
-    $outputString = $process->getOutput() . $process->getErrorOutput();
+    $outputString = $process->getOutput().$process->getErrorOutput();
 
     // Should contain some package names or "No recent changes"
     expect($outputString)->toContain('check')
@@ -42,7 +41,7 @@ test('main command executes without errors', function () {
     // Test without --ignore-last to avoid git history dependencies in CI
     $process = runWhatsDiff();
 
-    $outputString = $process->getOutput() . $process->getErrorOutput();
+    $outputString = $process->getOutput().$process->getErrorOutput();
 
     // Should produce some meaningful output
     expect(strlen($outputString))->toBeGreaterThan(0);
@@ -77,7 +76,7 @@ test('error handling works for invalid options', function () {
     $process = runWhatsDiff(['--invalid-option']);
 
     expect($process->getExitCode())->not->toBe(0);
-    $outputString = $process->getOutput() . $process->getErrorOutput();
+    $outputString = $process->getOutput().$process->getErrorOutput();
     expect($outputString)->toContain('The "--invalid-option" option does not exist');
 });
 
@@ -86,7 +85,7 @@ test('ignore-last option is properly recognized', function () {
     $process = runWhatsDiff(['--ignore-last', '--help']);
 
     expect($process->getExitCode())->toBe(0);
-    $outputString = $process->getOutput() . $process->getErrorOutput();
+    $outputString = $process->getOutput().$process->getErrorOutput();
     expect($outputString)->toContain('--ignore-last');
     expect($outputString)->toContain('Ignore last uncommitted changes');
 });

--- a/tests/Feature/Mcp/FindCompatibleVersionToolTest.php
+++ b/tests/Feature/Mcp/FindCompatibleVersionToolTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Tests\Helpers\McpServerHelper;
 
 beforeEach(function () {
-    $this->mcp = new McpServerHelper();
+    $this->mcp = new McpServerHelper;
     $this->mcp->initialize();
 });
 
@@ -15,10 +15,10 @@ afterEach(function () {
 
 it('can find compatible versions for a composer package', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'phpunit/phpunit',
-        'dependency_package'    => 'php',
+        'package' => 'phpunit/phpunit',
+        'dependency_package' => 'php',
         'dependency_constraint' => '^8.2',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     expect($response)
@@ -43,10 +43,10 @@ it('can find compatible versions for a composer package', function () {
 
 it('can find compatible versions for an npm package', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => '@types/node',
-        'dependency_package'    => 'typescript',
+        'package' => '@types/node',
+        'dependency_package' => 'typescript',
         'dependency_constraint' => '^5.0.0',
-        'package_manager'       => 'npm',
+        'package_manager' => 'npm',
     ]);
 
     expect($response)
@@ -66,10 +66,10 @@ it('can find compatible versions for an npm package', function () {
 
 it('returns error for invalid package manager', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'some/package',
-        'dependency_package'    => 'php',
+        'package' => 'some/package',
+        'dependency_package' => 'php',
         'dependency_constraint' => '^8.0',
-        'package_manager'       => 'invalid',
+        'package_manager' => 'invalid',
     ]);
 
     $result = $response['result'];
@@ -83,10 +83,10 @@ it('returns error for invalid package manager', function () {
 
 it('returns error for invalid version constraint', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'symfony/console',
-        'dependency_package'    => 'php',
+        'package' => 'symfony/console',
+        'dependency_package' => 'php',
         'dependency_constraint' => 'not-a-valid-constraint',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     $result = $response['result'];
@@ -100,10 +100,10 @@ it('returns error for invalid version constraint', function () {
 
 it('returns error when package is not found', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'nonexistent/package-that-does-not-exist-12345',
-        'dependency_package'    => 'php',
+        'package' => 'nonexistent/package-that-does-not-exist-12345',
+        'dependency_package' => 'php',
         'dependency_constraint' => '^8.0',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     $result = $response['result'];
@@ -117,10 +117,10 @@ it('returns error when package is not found', function () {
 
 it('returns empty compatible versions when no matches found', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'symfony/console',
-        'dependency_package'    => 'nonexistent/dependency',
+        'package' => 'symfony/console',
+        'dependency_package' => 'nonexistent/dependency',
         'dependency_constraint' => '^1.0',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     $result = $response['result'];
@@ -135,10 +135,10 @@ it('returns empty compatible versions when no matches found', function () {
 
 it('includes example version and requires information for each compatible version', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'laravel/framework',
-        'dependency_package'    => 'php',
+        'package' => 'laravel/framework',
+        'dependency_package' => 'php',
         'dependency_constraint' => '^8.2',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     $result = $response['result'];
@@ -161,8 +161,8 @@ it('includes example version and requires information for each compatible versio
 
 it('uses default package manager when not specified', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'symfony/console',
-        'dependency_package'    => 'php',
+        'package' => 'symfony/console',
+        'dependency_package' => 'php',
         'dependency_constraint' => '^8.2',
     ]);
 
@@ -178,10 +178,10 @@ it('uses default package manager when not specified', function () {
 
 it('sorts compatible versions by major version', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'symfony/console',
-        'dependency_package'    => 'php',
+        'package' => 'symfony/console',
+        'dependency_package' => 'php',
         'dependency_constraint' => '^8.0',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     $result = $response['result'];
@@ -199,10 +199,10 @@ it('sorts compatible versions by major version', function () {
 
 it('finds livewire versions compatible with illuminate/support', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'livewire/livewire',
-        'dependency_package'    => 'illuminate/support',
+        'package' => 'livewire/livewire',
+        'dependency_package' => 'illuminate/support',
         'dependency_constraint' => '^11.0',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     $result = $response['result'];
@@ -225,10 +225,10 @@ it('finds livewire versions compatible with illuminate/support', function () {
 
 it('finds illuminate/support versions compatible with PHP', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'illuminate/support',
-        'dependency_package'    => 'php',
+        'package' => 'illuminate/support',
+        'dependency_package' => 'php',
         'dependency_constraint' => '^8.2',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     $result = $response['result'];
@@ -252,10 +252,10 @@ it('finds illuminate/support versions compatible with PHP', function () {
 
 it('finds orchestra/testbench versions compatible with laravel/framework', function () {
     $response = $this->mcp->callTool('find_compatible_versions', [
-        'package'               => 'orchestra/testbench',
-        'dependency_package'    => 'laravel/framework',
+        'package' => 'orchestra/testbench',
+        'dependency_package' => 'laravel/framework',
         'dependency_constraint' => '^11.0',
-        'package_manager'       => 'composer',
+        'package_manager' => 'composer',
     ]);
 
     $result = $response['result'];

--- a/tests/Feature/Mcp/GetAvailableUpgradesToolTest.php
+++ b/tests/Feature/Mcp/GetAvailableUpgradesToolTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Tests\Helpers\McpServerHelper;
 
 beforeEach(function () {
-    $this->mcp = new McpServerHelper();
+    $this->mcp = new McpServerHelper;
     $this->mcp->initialize();
 });
 
@@ -15,7 +15,7 @@ afterEach(function () {
 
 it('can get available upgrades for a composer package', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => '6.3.0',
         'package_manager' => 'composer',
     ]);
@@ -59,7 +59,7 @@ it('can get available upgrades for a composer package', function () {
 
 it('can get available upgrades for an npm package', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'react',
+        'package' => 'react',
         'current_version' => '18.2.0',
         'package_manager' => 'npm',
     ]);
@@ -81,7 +81,7 @@ it('can get available upgrades for an npm package', function () {
 
 it('returns error for invalid package manager', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'some/package',
+        'package' => 'some/package',
         'current_version' => '1.0.0',
         'package_manager' => 'invalid',
     ]);
@@ -97,7 +97,7 @@ it('returns error for invalid package manager', function () {
 
 it('returns error for invalid version format', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => 'not-a-valid-version',
         'package_manager' => 'composer',
     ]);
@@ -113,7 +113,7 @@ it('returns error for invalid version format', function () {
 
 it('returns error when package is not found', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'nonexistent/package-that-does-not-exist-12345',
+        'package' => 'nonexistent/package-that-does-not-exist-12345',
         'current_version' => '1.0.0',
         'package_manager' => 'composer',
     ]);
@@ -130,7 +130,7 @@ it('returns error when package is not found', function () {
 it('returns null for patch when no patch upgrade available', function () {
     // Use a recent version that likely doesn't have a newer patch
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => '7.2.999',
         'package_manager' => 'composer',
     ]);
@@ -149,7 +149,7 @@ it('returns null for patch when no patch upgrade available', function () {
 it('returns null for all upgrade types when already at latest version', function () {
     // Use a very high version number that doesn't exist
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => '99.99.99',
         'package_manager' => 'composer',
     ]);
@@ -167,7 +167,7 @@ it('returns null for all upgrade types when already at latest version', function
 
 it('uses default package manager when not specified', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => '6.4.0',
     ]);
 
@@ -183,7 +183,7 @@ it('uses default package manager when not specified', function () {
 
 it('finds latest patch version not first', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => '7.0.0',
         'package_manager' => 'composer',
     ]);
@@ -202,7 +202,7 @@ it('finds latest patch version not first', function () {
 
 it('finds latest minor version not first', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => '7.0.0',
         'package_manager' => 'composer',
     ]);
@@ -221,7 +221,7 @@ it('finds latest minor version not first', function () {
 
 it('finds latest major version not first', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => '6.3.0',
         'package_manager' => 'composer',
     ]);
@@ -240,7 +240,7 @@ it('finds latest major version not first', function () {
 
 it('skips dev versions when finding upgrades', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'laravel/framework',
+        'package' => 'laravel/framework',
         'current_version' => '11.0.0',
         'package_manager' => 'composer',
     ]);
@@ -262,7 +262,7 @@ it('skips dev versions when finding upgrades', function () {
 it('handles versions with v prefix correctly', function () {
     // This is the exact issue that was reported
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'         => 'symfony/console',
+        'package' => 'symfony/console',
         'current_version' => '6.3.0',
         'package_manager' => 'composer',
     ]);
@@ -283,9 +283,9 @@ it('handles versions with v prefix correctly', function () {
 
 it('excludes pre-release versions by default', function () {
     $response = $this->mcp->callTool('get_available_upgrades', [
-        'package'            => 'symfony/console',
-        'current_version'    => '6.3.0',
-        'package_manager'    => 'composer',
+        'package' => 'symfony/console',
+        'current_version' => '6.3.0',
+        'package_manager' => 'composer',
         'include_prerelease' => false,
     ]);
 
@@ -311,16 +311,16 @@ it('excludes pre-release versions by default', function () {
 
 it('includes pre-release versions when requested', function () {
     $responseWithoutPrerelease = $this->mcp->callTool('get_available_upgrades', [
-        'package'            => 'symfony/console',
-        'current_version'    => '7.3.0',
-        'package_manager'    => 'composer',
+        'package' => 'symfony/console',
+        'current_version' => '7.3.0',
+        'package_manager' => 'composer',
         'include_prerelease' => false,
     ]);
 
     $responseWithPrerelease = $this->mcp->callTool('get_available_upgrades', [
-        'package'            => 'symfony/console',
-        'current_version'    => '7.3.0',
-        'package_manager'    => 'composer',
+        'package' => 'symfony/console',
+        'current_version' => '7.3.0',
+        'package_manager' => 'composer',
         'include_prerelease' => true,
     ]);
 

--- a/tests/Feature/Mcp/GetDependencyConstraintsToolTest.php
+++ b/tests/Feature/Mcp/GetDependencyConstraintsToolTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Tests\Helpers\McpServerHelper;
 
 beforeEach(function () {
-    $this->mcp = new McpServerHelper();
+    $this->mcp = new McpServerHelper;
     $this->mcp->initialize();
 });
 
@@ -15,8 +15,8 @@ afterEach(function () {
 
 it('can get dependency constraints for a composer package version', function () {
     $response = $this->mcp->callTool('get_dependency_constraints', [
-        'package'         => 'livewire/livewire',
-        'version'         => 'v3.0.0',
+        'package' => 'livewire/livewire',
+        'version' => 'v3.0.0',
         'package_manager' => 'composer',
     ]);
 
@@ -44,8 +44,8 @@ it('can get dependency constraints for a composer package version', function () 
 
 it('can get dependency constraints for an npm package version', function () {
     $response = $this->mcp->callTool('get_dependency_constraints', [
-        'package'         => 'react',
-        'version'         => '18.2.0',
+        'package' => 'react',
+        'version' => '18.2.0',
         'package_manager' => 'npm',
     ]);
 
@@ -71,8 +71,8 @@ it('can get dependency constraints for an npm package version', function () {
 
 it('returns error for invalid package manager', function () {
     $response = $this->mcp->callTool('get_dependency_constraints', [
-        'package'         => 'some/package',
-        'version'         => '1.0.0',
+        'package' => 'some/package',
+        'version' => '1.0.0',
         'package_manager' => 'invalid',
     ]);
 
@@ -87,8 +87,8 @@ it('returns error for invalid package manager', function () {
 
 it('returns error when package is not found', function () {
     $response = $this->mcp->callTool('get_dependency_constraints', [
-        'package'         => 'nonexistent/package-that-does-not-exist-12345',
-        'version'         => '1.0.0',
+        'package' => 'nonexistent/package-that-does-not-exist-12345',
+        'version' => '1.0.0',
         'package_manager' => 'composer',
     ]);
 
@@ -103,8 +103,8 @@ it('returns error when package is not found', function () {
 
 it('returns error when version is not found', function () {
     $response = $this->mcp->callTool('get_dependency_constraints', [
-        'package'         => 'symfony/console',
-        'version'         => '999.999.999',
+        'package' => 'symfony/console',
+        'version' => '999.999.999',
         'package_manager' => 'composer',
     ]);
 
@@ -136,14 +136,14 @@ it('uses default package manager when not specified', function () {
 
 it('handles version with or without v prefix', function () {
     $responseWithV = $this->mcp->callTool('get_dependency_constraints', [
-        'package'         => 'symfony/console',
-        'version'         => 'v6.4.0',
+        'package' => 'symfony/console',
+        'version' => 'v6.4.0',
         'package_manager' => 'composer',
     ]);
 
     $responseWithoutV = $this->mcp->callTool('get_dependency_constraints', [
-        'package'         => 'symfony/console',
-        'version'         => '6.4.0',
+        'package' => 'symfony/console',
+        'version' => '6.4.0',
         'package_manager' => 'composer',
     ]);
 
@@ -158,8 +158,8 @@ it('handles version with or without v prefix', function () {
 
 it('returns proper dependency structure for packages', function () {
     $response = $this->mcp->callTool('get_dependency_constraints', [
-        'package'         => 'symfony/console',
-        'version'         => 'v6.4.0',
+        'package' => 'symfony/console',
+        'version' => 'v6.4.0',
         'package_manager' => 'composer',
     ]);
 

--- a/tests/Feature/Mcp/GetReleaseNotesToolTest.php
+++ b/tests/Feature/Mcp/GetReleaseNotesToolTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Tests\Helpers\McpServerHelper;
 
 beforeEach(function () {
-    $this->mcp = new McpServerHelper();
+    $this->mcp = new McpServerHelper;
     $this->mcp->initialize();
 });
 
@@ -15,9 +15,9 @@ afterEach(function () {
 
 it('can fetch release notes for a composer package', function () {
     $response = $this->mcp->callTool('get_release_notes', [
-        'package'         => 'symfony/console',
-        'from_version'    => '7.0.0',
-        'to_version'      => '7.0.3',
+        'package' => 'symfony/console',
+        'from_version' => '7.0.0',
+        'to_version' => '7.0.3',
         'package_manager' => 'composer',
     ]);
 
@@ -53,9 +53,9 @@ it('can fetch release notes for a composer package', function () {
 
 it('can fetch release notes for an npm package', function () {
     $response = $this->mcp->callTool('get_release_notes', [
-        'package'         => 'react',
-        'from_version'    => '18.2.0',
-        'to_version'      => '18.3.0',
+        'package' => 'react',
+        'from_version' => '18.2.0',
+        'to_version' => '18.3.0',
         'package_manager' => 'npm',
     ]);
 
@@ -77,9 +77,9 @@ it('can fetch release notes for an npm package', function () {
 
 it('returns error for invalid package manager', function () {
     $response = $this->mcp->callTool('get_release_notes', [
-        'package'         => 'some/package',
-        'from_version'    => '1.0.0',
-        'to_version'      => '2.0.0',
+        'package' => 'some/package',
+        'from_version' => '1.0.0',
+        'to_version' => '2.0.0',
         'package_manager' => 'invalid',
     ]);
 
@@ -94,9 +94,9 @@ it('returns error for invalid package manager', function () {
 
 it('returns error when package repository is not found', function () {
     $response = $this->mcp->callTool('get_release_notes', [
-        'package'         => 'nonexistent/package-that-does-not-exist-12345',
-        'from_version'    => '1.0.0',
-        'to_version'      => '2.0.0',
+        'package' => 'nonexistent/package-that-does-not-exist-12345',
+        'from_version' => '1.0.0',
+        'to_version' => '2.0.0',
         'package_manager' => 'composer',
     ]);
 
@@ -111,9 +111,9 @@ it('returns error when package repository is not found', function () {
 
 it('returns empty releases when no releases found in range', function () {
     $response = $this->mcp->callTool('get_release_notes', [
-        'package'         => 'symfony/console',
-        'from_version'    => '99.0.0',
-        'to_version'      => '99.9.9',
+        'package' => 'symfony/console',
+        'from_version' => '99.0.0',
+        'to_version' => '99.9.9',
         'package_manager' => 'composer',
     ]);
 
@@ -130,9 +130,9 @@ it('returns empty releases when no releases found in range', function () {
 
 it('includes release details when releases are found', function () {
     $response = $this->mcp->callTool('get_release_notes', [
-        'package'         => 'laravel/framework',
-        'from_version'    => '12.0.0',
-        'to_version'      => '12.1.0',
+        'package' => 'laravel/framework',
+        'from_version' => '12.0.0',
+        'to_version' => '12.1.0',
         'package_manager' => 'composer',
     ]);
 
@@ -152,9 +152,9 @@ it('includes release details when releases are found', function () {
 
 it('uses default package manager when not specified', function () {
     $response = $this->mcp->callTool('get_release_notes', [
-        'package'      => 'symfony/console',
+        'package' => 'symfony/console',
         'from_version' => '7.0.0',
-        'to_version'   => '7.0.1',
+        'to_version' => '7.0.1',
     ]);
 
     $result = $response['result'];

--- a/tests/Feature/Mcp/ListToolsTest.php
+++ b/tests/Feature/Mcp/ListToolsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Tests\Helpers\McpServerHelper;
 
 beforeEach(function () {
-    $this->mcp = new McpServerHelper();
+    $this->mcp = new McpServerHelper;
 });
 
 afterEach(function () {

--- a/tests/Feature/OutputFormatsTest.php
+++ b/tests/Feature/OutputFormatsTest.php
@@ -115,7 +115,7 @@ test('markdown format outputs proper markdown structure', function () {
     // Add a package
     $updatedComposerLock = generateComposerLock([
         'guzzlehttp/guzzle' => '7.4.0',
-        'monolog/monolog'   => '3.0.0',
+        'monolog/monolog' => '3.0.0',
     ]);
 
     file_put_contents($this->tempDir.'/composer.lock', $updatedComposerLock);

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -28,7 +28,6 @@ function initTempDirectory(bool $initGit = true): string
     return $tempDir;
 }
 
-
 function cleanupTempDirectory(string $tempDir): void
 {
     if (! is_dir($tempDir)) {
@@ -41,31 +40,30 @@ function cleanupTempDirectory(string $tempDir): void
         // Use PowerShell Remove-Item with Force - most effective for locked files
         $process = new SymfonyProcess([
             'powershell', '-Command',
-            "Remove-Item -Path '$tempDir' -Recurse -Force -ErrorAction SilentlyContinue"
+            "Remove-Item -Path '$tempDir' -Recurse -Force -ErrorAction SilentlyContinue",
         ]);
         $process->setTimeout(30);
         $process->run();
 
         // If PowerShell fails, try standard rmdir as backup
-        if (!$process->isSuccessful() && is_dir($tempDir)) {
+        if (! $process->isSuccessful() && is_dir($tempDir)) {
             $process = new SymfonyProcess(['cmd', '/c', 'rmdir', '/s', '/q', $tempDir]);
             $process->run();
         }
 
         // Final check and warning
         if (is_dir($tempDir)) {
-            echo "Warning: Could not clean up temp directory: ".$tempDir."\n";
+            echo 'Warning: Could not clean up temp directory: '.$tempDir."\n";
         }
     } else {
         $process = new SymfonyProcess(['rm', '-rf', $tempDir]);
         $process->run();
 
         if (! $process->isSuccessful()) {
-            echo "Warning: Could not clean up temp directory: ".$tempDir."\n";
+            echo 'Warning: Could not clean up temp directory: '.$tempDir."\n";
         }
     }
 }
-
 
 function runCommand(string $command, ?string $cwd = null): string
 {
@@ -101,7 +99,7 @@ function runCommand(string $command, ?string $cwd = null): string
         if (PHP_OS_FAMILY === 'Windows' && str_contains($command, 'rmdir') &&
             str_contains($process->getErrorOutput(), 'being used by another process')) {
             // Just warn, don't fail - this is a common Windows issue
-            echo "Warning: Could not clean up temp directory (file in use): ".$command."\n";
+            echo 'Warning: Could not clean up temp directory (file in use): '.$command."\n";
 
             return $process->getOutput();
         }
@@ -111,17 +109,16 @@ function runCommand(string $command, ?string $cwd = null): string
     return $process->getOutput();
 }
 
-
 function runWhatsDiff(array $args = [], ?string $cwd = null): SymfonyProcess
 {
     $workingDir = $cwd ?? test()->tempDir ?? getcwd();
     $binPath = realpath(__DIR__.'/../bin/whatsdiff');
 
     // Find PHP executable
-    $executableFinder = new ExecutableFinder();
+    $executableFinder = new ExecutableFinder;
     $phpBinary = $executableFinder->find('php');
 
-    if (!$phpBinary) {
+    if (! $phpBinary) {
         throw new \RuntimeException('PHP executable not found');
     }
 
@@ -141,7 +138,7 @@ function runWhatsDiff(array $args = [], ?string $cwd = null): SymfonyProcess
 /**
  * Generate a composer.lock file content from a simple package array
  *
- * @param array<string, string> $packages Array of packages with format ['package/name' => 'version']
+ * @param  array<string, string>  $packages  Array of packages with format ['package/name' => 'version']
  * @return string JSON content for composer.lock
  */
 function generateComposerLock(array $packages): string
@@ -190,7 +187,7 @@ function generateComposerLock(array $packages): string
 /**
  * Generate a package-lock.json file content from a simple package array
  *
- * @param array<string, string> $packages Array of packages with format ['package-name' => 'version']
+ * @param  array<string, string>  $packages  Array of packages with format ['package-name' => 'version']
  * @return string JSON content for package-lock.json
  */
 function generatePackageLock(array $packages): string
@@ -210,7 +207,7 @@ function generatePackageLock(array $packages): string
         $lockPackages["node_modules/{$name}"] = [
             'version' => $version,
             'resolved' => "https://registry.npmjs.org/{$name}/-/{$name}-{$version}.tgz",
-            'integrity' => 'sha512-' . base64_encode(random_bytes(32)),
+            'integrity' => 'sha512-'.base64_encode(random_bytes(32)),
             'license' => 'MIT',
         ];
 

--- a/tests/Helpers/McpServerHelper.php
+++ b/tests/Helpers/McpServerHelper.php
@@ -24,11 +24,12 @@ class McpServerHelper
     private $stderr;
 
     private int $requestId = 1;
+
     private bool $initialized = false;
 
     public function __construct()
     {
-        $serverPath = __DIR__ . '/../../bin/whatsdiff-mcp';
+        $serverPath = __DIR__.'/../../bin/whatsdiff-mcp';
 
         $descriptorspec = [
             0 => ['pipe', 'r'],  // stdin
@@ -42,7 +43,7 @@ class McpServerHelper
             $pipes
         );
 
-        if (!is_resource($this->process)) {
+        if (! is_resource($this->process)) {
             throw new \RuntimeException('Failed to start MCP server process');
         }
 
@@ -65,7 +66,7 @@ class McpServerHelper
         $response = $this->sendRequest('initialize', [
             'protocolVersion' => '2024-11-05',
             'capabilities' => [
-                'tools' => new \stdClass(),
+                'tools' => new \stdClass,
             ],
             'clientInfo' => [
                 'name' => 'whatsdiff-test-client',
@@ -84,8 +85,8 @@ class McpServerHelper
     /**
      * Send a JSON-RPC notification (no response expected).
      *
-     * @param string $method JSON-RPC method name
-     * @param array<string, mixed> $params Method parameters
+     * @param  string  $method  JSON-RPC method name
+     * @param  array<string, mixed>  $params  Method parameters
      */
     private function sendNotification(string $method, array $params): void
     {
@@ -95,7 +96,7 @@ class McpServerHelper
             'params' => $params,
         ];
 
-        $notificationJson = json_encode($notification, JSON_UNESCAPED_SLASHES) . "\n";
+        $notificationJson = json_encode($notification, JSON_UNESCAPED_SLASHES)."\n";
 
         // Write notification to server stdin
         fwrite($this->stdin, $notificationJson);
@@ -118,8 +119,8 @@ class McpServerHelper
     /**
      * Call a specific tool with given arguments.
      *
-     * @param string $toolName Tool name to call
-     * @param array<string, mixed> $arguments Tool arguments
+     * @param  string  $toolName  Tool name to call
+     * @param  array<string, mixed>  $arguments  Tool arguments
      */
     public function callTool(string $toolName, array $arguments): array
     {
@@ -134,9 +135,10 @@ class McpServerHelper
     /**
      * Send a JSON-RPC request to the server and wait for response.
      *
-     * @param string $method JSON-RPC method name
-     * @param array<string, mixed> $params Method parameters
+     * @param  string  $method  JSON-RPC method name
+     * @param  array<string, mixed>  $params  Method parameters
      * @return array<string, mixed> Response data
+     *
      * @throws \RuntimeException If server communication fails
      */
     public function sendRequest(string $method, array $params): array
@@ -150,7 +152,7 @@ class McpServerHelper
             'params' => $params,
         ];
 
-        $requestJson = json_encode($request, JSON_UNESCAPED_SLASHES) . "\n";
+        $requestJson = json_encode($request, JSON_UNESCAPED_SLASHES)."\n";
 
         // Write request to server stdin
         fwrite($this->stdin, $requestJson);
@@ -165,8 +167,9 @@ class McpServerHelper
     /**
      * Read a JSON-RPC response from the server stdout.
      *
-     * @param int $expectedId Expected request ID
+     * @param  int  $expectedId  Expected request ID
      * @return array<string, mixed> Response data
+     *
      * @throws \RuntimeException If response cannot be read or parsed
      */
     private function readResponse(int $expectedId): array
@@ -178,7 +181,7 @@ class McpServerHelper
         while ($attempts < $maxAttempts) {
             // Check if process is still running
             $status = proc_get_status($this->process);
-            if (!$status['running']) {
+            if (! $status['running']) {
                 $errorOutput = stream_get_contents($this->stderr);
                 throw new \RuntimeException(
                     "MCP server process terminated unexpectedly. Error output: {$errorOutput}"
@@ -188,7 +191,7 @@ class McpServerHelper
             // Read available output from stdout
             $output = fread($this->stdout, 8192);
 
-            if ($output !== false && !empty($output)) {
+            if ($output !== false && ! empty($output)) {
                 $accumulatedOutput .= $output;
 
                 // Try to parse complete JSON lines
@@ -212,7 +215,7 @@ class McpServerHelper
                     }
 
                     // Check if this is a JSON-RPC response for our request
-                    if (!isset($response['jsonrpc']) || $response['jsonrpc'] !== '2.0') {
+                    if (! isset($response['jsonrpc']) || $response['jsonrpc'] !== '2.0') {
                         continue;
                     }
 
@@ -221,7 +224,7 @@ class McpServerHelper
                         // Check for JSON-RPC error
                         if (isset($response['error'])) {
                             throw new \RuntimeException(
-                                'MCP server returned error: ' . json_encode($response['error'])
+                                'MCP server returned error: '.json_encode($response['error'])
                             );
                         }
 
@@ -234,7 +237,7 @@ class McpServerHelper
             $attempts++;
         }
 
-        throw new \RuntimeException('Timeout waiting for MCP server response (ID: ' . $expectedId . ')');
+        throw new \RuntimeException('Timeout waiting for MCP server response (ID: '.$expectedId.')');
     }
 
     /**
@@ -242,7 +245,7 @@ class McpServerHelper
      */
     private function ensureInitialized(): void
     {
-        if (!$this->initialized) {
+        if (! $this->initialized) {
             $this->initialize();
         }
     }
@@ -252,7 +255,7 @@ class McpServerHelper
      */
     public function stop(): void
     {
-        if (!is_resource($this->process)) {
+        if (! is_resource($this->process)) {
             return; // Already stopped
         }
 

--- a/tests/Integration/FakeGitRepositoryTest.php
+++ b/tests/Integration/FakeGitRepositoryTest.php
@@ -6,7 +6,7 @@ use Whatsdiff\Services\GitRepository;
 
 beforeEach(function () {
     $this->tempDir = initTempDirectory();
-    $this->gitRepository = new GitRepository();
+    $this->gitRepository = new GitRepository;
 });
 
 afterEach(function () {
@@ -39,7 +39,7 @@ it('handles npm only changes with add, update, downgrade, and remove', function 
         ],
     ];
 
-    file_put_contents($this->tempDir . '/package-lock.json', json_encode($initialPackageLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/package-lock.json', json_encode($initialPackageLock, JSON_PRETTY_PRINT));
     runCommand('git add package-lock.json');
     runCommand('git commit -m "Initial package-lock.json"');
 
@@ -69,28 +69,26 @@ it('handles npm only changes with add, update, downgrade, and remove', function 
         ],
     ];
 
-    file_put_contents($this->tempDir . '/package-lock.json', json_encode($updatedPackageLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/package-lock.json', json_encode($updatedPackageLock, JSON_PRETTY_PRINT));
     runCommand('git add package-lock.json');
     runCommand('git commit -m "Update npm dependencies"');
-
 
     // Run whatsdiff with JSON output
     $process = runWhatsDiff(['--format=json']);
     $output = $process->getOutput();
 
-
     $result = json_decode($output, true);
 
     // Debug output if null
     if ($result === null) {
-        throw new \Exception("JSON decode failed. Raw output: " . $output);
+        throw new \Exception('JSON decode failed. Raw output: '.$output);
     }
 
     // Add Windows debugging for empty diffs
     if (PHP_OS_FAMILY === 'Windows' && isset($result['diffs']) && empty($result['diffs'])) {
         echo "\n--- WINDOWS DEBUG: Empty diffs detected ---\n";
-        echo "Full whatsdiff output: " . $output . "\n";
-        echo "Parsed result: " . print_r($result, true) . "\n";
+        echo 'Full whatsdiff output: '.$output."\n";
+        echo 'Parsed result: '.print_r($result, true)."\n";
         echo "---------------------------------------------\n";
     }
 
@@ -166,7 +164,7 @@ it('handles composer only changes', function () {
         ],
     ];
 
-    file_put_contents($this->tempDir . '/composer.lock', json_encode($initialComposerLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/composer.lock', json_encode($initialComposerLock, JSON_PRETTY_PRINT));
     runCommand('git add composer.lock');
     runCommand('git commit -m "Initial composer.lock"');
 
@@ -208,7 +206,7 @@ it('handles composer only changes', function () {
         ],
     ];
 
-    file_put_contents($this->tempDir . '/composer.lock', json_encode($updatedComposerLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/composer.lock', json_encode($updatedComposerLock, JSON_PRETTY_PRINT));
     runCommand('git add composer.lock');
     runCommand('git commit -m "Update composer dependencies"');
 
@@ -219,7 +217,7 @@ it('handles composer only changes', function () {
 
     // Debug output if null
     if ($result === null) {
-        throw new \Exception("JSON decode failed. Raw output: " . $output);
+        throw new \Exception('JSON decode failed. Raw output: '.$output);
     }
 
     expect($result)->toBeArray();
@@ -259,8 +257,8 @@ it('handles both composer and npm changes across multiple commits', function () 
         ],
     ];
 
-    file_put_contents($this->tempDir . '/composer.lock', json_encode($initialComposerLock, JSON_PRETTY_PRINT));
-    file_put_contents($this->tempDir . '/package-lock.json', json_encode($initialPackageLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/composer.lock', json_encode($initialComposerLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/package-lock.json', json_encode($initialPackageLock, JSON_PRETTY_PRINT));
     runCommand('git add .');
     runCommand('git commit -m "Initial state"');
 
@@ -276,7 +274,7 @@ it('handles both composer and npm changes across multiple commits', function () 
         ],
     ];
 
-    file_put_contents($this->tempDir . '/composer.lock', json_encode($updatedComposerLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/composer.lock', json_encode($updatedComposerLock, JSON_PRETTY_PRINT));
     runCommand('git add composer.lock');
     runCommand('git commit -m "Update composer dependencies"');
 
@@ -294,7 +292,7 @@ it('handles both composer and npm changes across multiple commits', function () 
         ],
     ];
 
-    file_put_contents($this->tempDir . '/package-lock.json', json_encode($updatedPackageLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/package-lock.json', json_encode($updatedPackageLock, JSON_PRETTY_PRINT));
     runCommand('git add package-lock.json');
     runCommand('git commit -m "Update npm dependencies"');
 
@@ -305,7 +303,7 @@ it('handles both composer and npm changes across multiple commits', function () 
 
     // Debug output if null
     if ($result === null) {
-        throw new \Exception("JSON decode failed. Raw output: " . $output);
+        throw new \Exception('JSON decode failed. Raw output: '.$output);
     }
 
     expect($result)->toBeArray();
@@ -329,13 +327,13 @@ it('shows no changes when there are several commits without dependency updates',
         ],
     ];
 
-    file_put_contents($this->tempDir . '/composer.lock', json_encode($initialComposerLock, JSON_PRETTY_PRINT));
+    file_put_contents($this->tempDir.'/composer.lock', json_encode($initialComposerLock, JSON_PRETTY_PRINT));
     runCommand('git add composer.lock');
     runCommand('git commit -m "Initial composer.lock"');
 
     // Add several commits without dependency changes
     for ($i = 1; $i <= 5; $i++) {
-        file_put_contents($this->tempDir . "/file{$i}.txt", "Content {$i}");
+        file_put_contents($this->tempDir."/file{$i}.txt", "Content {$i}");
         runCommand("git add file{$i}.txt");
         runCommand("git commit -m 'Add file {$i}'");
     }
@@ -347,14 +345,14 @@ it('shows no changes when there are several commits without dependency updates',
 
     // Debug output if null
     if ($result === null) {
-        throw new \Exception("JSON decode failed. Raw output: " . $output);
+        throw new \Exception('JSON decode failed. Raw output: '.$output);
     }
 
     expect($result)->toBeArray();
     expect($result)->toHaveKey('diffs');
     // Since we have commits with the composer.lock file, there may be some diff detected
     // The test should verify no recent changes are detected
-    if (!empty($result['diffs'])) {
+    if (! empty($result['diffs'])) {
         expect($result['has_uncommitted_changes'])->toBeFalse();
     }
 });

--- a/tests/Mocks/MockHttpService.php
+++ b/tests/Mocks/MockHttpService.php
@@ -9,7 +9,9 @@ use Whatsdiff\Services\HttpService;
 class MockHttpService extends HttpService
 {
     public array $responses = [];
+
     public array $capturedOptions = [];
+
     public ?string $lastRequestUrl = null;
 
     public function __construct()
@@ -27,11 +29,12 @@ class MockHttpService extends HttpService
         $this->capturedOptions = $options; // Capture the auth options
         $this->lastRequestUrl = $url; // Track which URL was called
 
-        if (!isset($this->responses[$url])) {
+        if (! isset($this->responses[$url])) {
             // Simulate authentication failure for private packages
             if (str_contains($url, 'flux-pro')) {
                 throw new \Exception('HTTP 401 Unauthorized');
             }
+
             return '{"packages":{}}'; // Default empty response for public packages
         }
 
@@ -42,7 +45,7 @@ class MockHttpService extends HttpService
     {
         return [
             'content' => $this->get($url, $options),
-            'headers' => []
+            'headers' => [],
         ];
     }
 }

--- a/tests/Mocks/TestServiceProvider.php
+++ b/tests/Mocks/TestServiceProvider.php
@@ -22,12 +22,11 @@ class TestServiceProvider
 {
     public function __construct(
         private readonly HttpService $mockHttpService
-    ) {
-    }
+    ) {}
 
     public function register(ContainerInterface $container): void
     {
-        if (!$container instanceof Container) {
+        if (! $container instanceof Container) {
             throw new \InvalidArgumentException('Container must be an instance of League\Container\Container');
         }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -39,4 +39,4 @@
 |
 */
 
-require_once __DIR__ . '/Helpers.php';
+require_once __DIR__.'/Helpers.php';

--- a/tests/Unit/Analyzers/NpmAnalyzerTest.php
+++ b/tests/Unit/Analyzers/NpmAnalyzerTest.php
@@ -168,7 +168,6 @@ it('gets releases count successfully', function () {
     expect($result)->toBe(6);
 });
 
-
 it('handles scoped packages correctly', function () {
     $packageLockContent = [
         'packages' => [

--- a/tests/Unit/Analyzers/Registries/PackagistRegistryTest.php
+++ b/tests/Unit/Analyzers/Registries/PackagistRegistryTest.php
@@ -346,7 +346,7 @@ it('uses support.source as last resort when other sources not available', functi
 
 it('loads auth from local auth.json and applies automatically', function () {
     // Create temporary directory with auth.json
-    $tempDir = sys_get_temp_dir() . '/whatsdiff-test-' . uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
     mkdir($tempDir);
 
     $authContent = [
@@ -358,7 +358,7 @@ it('loads auth from local auth.json and applies automatically', function () {
         ],
     ];
 
-    file_put_contents($tempDir . '/auth.json', json_encode($authContent));
+    file_put_contents($tempDir.'/auth.json', json_encode($authContent));
 
     $originalDir = getcwd();
     chdir($tempDir);
@@ -391,18 +391,18 @@ it('loads auth from local auth.json and applies automatically', function () {
         expect($result)->toBe($packageData);
     } finally {
         chdir($originalDir);
-        unlink($tempDir . '/auth.json');
+        unlink($tempDir.'/auth.json');
         rmdir($tempDir);
     }
 });
 
 it('loads auth from both local and global with local taking precedence', function () {
     // Create temporary directories
-    $tempDir = sys_get_temp_dir() . '/whatsdiff-test-' . uniqid();
-    $homeDir = sys_get_temp_dir() . '/whatsdiff-home-' . uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
+    $homeDir = sys_get_temp_dir().'/whatsdiff-home-'.uniqid();
     mkdir($tempDir);
     mkdir($homeDir);
-    mkdir($homeDir . '/.composer');
+    mkdir($homeDir.'/.composer');
 
     $localAuth = [
         'http-basic' => [
@@ -426,8 +426,8 @@ it('loads auth from both local and global with local taking precedence', functio
         ],
     ];
 
-    file_put_contents($tempDir . '/auth.json', json_encode($localAuth));
-    file_put_contents($homeDir . '/.composer/auth.json', json_encode($globalAuth));
+    file_put_contents($tempDir.'/auth.json', json_encode($localAuth));
+    file_put_contents($homeDir.'/.composer/auth.json', json_encode($globalAuth));
 
     // Set HOME environment variable
     $originalHome = getenv('HOME') ?: getenv('USERPROFILE');
@@ -459,9 +459,9 @@ it('loads auth from both local and global with local taking precedence', functio
     } finally {
         chdir($originalDir);
         putenv("HOME={$originalHome}");
-        unlink($tempDir . '/auth.json');
-        unlink($homeDir . '/.composer/auth.json');
-        rmdir($homeDir . '/.composer');
+        unlink($tempDir.'/auth.json');
+        unlink($homeDir.'/.composer/auth.json');
+        rmdir($homeDir.'/.composer');
         rmdir($homeDir);
         rmdir($tempDir);
     }
@@ -469,11 +469,11 @@ it('loads auth from both local and global with local taking precedence', functio
 
 it('uses global auth when local auth.json does not exist', function () {
     // Create temporary directories
-    $tempDir = sys_get_temp_dir() . '/whatsdiff-test-' . uniqid();
-    $homeDir = sys_get_temp_dir() . '/whatsdiff-home-' . uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
+    $homeDir = sys_get_temp_dir().'/whatsdiff-home-'.uniqid();
     mkdir($tempDir);
     mkdir($homeDir);
-    mkdir($homeDir . '/.composer');
+    mkdir($homeDir.'/.composer');
 
     $globalAuth = [
         'http-basic' => [
@@ -484,7 +484,7 @@ it('uses global auth when local auth.json does not exist', function () {
         ],
     ];
 
-    file_put_contents($homeDir . '/.composer/auth.json', json_encode($globalAuth));
+    file_put_contents($homeDir.'/.composer/auth.json', json_encode($globalAuth));
 
     // Set HOME environment variable
     $originalHome = getenv('HOME') ?: getenv('USERPROFILE');
@@ -516,8 +516,8 @@ it('uses global auth when local auth.json does not exist', function () {
     } finally {
         chdir($originalDir);
         putenv("HOME={$originalHome}");
-        unlink($homeDir . '/.composer/auth.json');
-        rmdir($homeDir . '/.composer');
+        unlink($homeDir.'/.composer/auth.json');
+        rmdir($homeDir.'/.composer');
         rmdir($homeDir);
         rmdir($tempDir);
     }
@@ -525,7 +525,7 @@ it('uses global auth when local auth.json does not exist', function () {
 
 it('explicit auth options override auth.json', function () {
     // Create temporary directory with auth.json
-    $tempDir = sys_get_temp_dir() . '/whatsdiff-test-' . uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
     mkdir($tempDir);
 
     $authContent = [
@@ -537,7 +537,7 @@ it('explicit auth options override auth.json', function () {
         ],
     ];
 
-    file_put_contents($tempDir . '/auth.json', json_encode($authContent));
+    file_put_contents($tempDir.'/auth.json', json_encode($authContent));
 
     $originalDir = getcwd();
     chdir($tempDir);
@@ -568,14 +568,14 @@ it('explicit auth options override auth.json', function () {
         expect($result)->toBe($packageData);
     } finally {
         chdir($originalDir);
-        unlink($tempDir . '/auth.json');
+        unlink($tempDir.'/auth.json');
         rmdir($tempDir);
     }
 });
 
 it('does not apply auth when domain does not match auth.json', function () {
     // Create temporary directory with auth.json
-    $tempDir = sys_get_temp_dir() . '/whatsdiff-test-' . uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
     mkdir($tempDir);
 
     $authContent = [
@@ -587,7 +587,7 @@ it('does not apply auth when domain does not match auth.json', function () {
         ],
     ];
 
-    file_put_contents($tempDir . '/auth.json', json_encode($authContent));
+    file_put_contents($tempDir.'/auth.json', json_encode($authContent));
 
     $originalDir = getcwd();
     chdir($tempDir);
@@ -607,7 +607,7 @@ it('does not apply auth when domain does not match auth.json', function () {
         expect($result)->toBe($packageData);
     } finally {
         chdir($originalDir);
-        unlink($tempDir . '/auth.json');
+        unlink($tempDir.'/auth.json');
         rmdir($tempDir);
     }
 });

--- a/tests/Unit/Analyzers/ReleaseNotes/ChangelogParserTest.php
+++ b/tests/Unit/Analyzers/ReleaseNotes/ChangelogParserTest.php
@@ -22,7 +22,7 @@ test('it parses basic Keep a Changelog format', function () {
 - Initial release
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0');
 
     expect($result)->toBeInstanceOf(ReleaseNotesCollection::class);
@@ -41,7 +41,7 @@ test('it handles version with brackets', function () {
 - Feature
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0');
 
     expect($result->count())->toBe(1);
@@ -55,7 +55,7 @@ test('it handles version with v prefix', function () {
 - Feature
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0');
 
     expect($result->count())->toBe(1);
@@ -69,7 +69,7 @@ test('it handles version with parentheses date', function () {
 - Feature
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0');
 
     expect($result->count())->toBe(1);
@@ -91,7 +91,7 @@ test('it filters versions by range', function () {
 - Version 1
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0');
 
     expect($result->count())->toBe(1);
@@ -109,7 +109,7 @@ test('it returns exact version when from and to are the same', function () {
 - Version 1
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '2.0.0', '2.0.0');
 
     expect($result->count())->toBe(1);
@@ -131,7 +131,7 @@ test('it excludes pre-release versions by default', function () {
 - Version 1
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0', includePrerelease: false);
 
     expect($result->count())->toBe(1);
@@ -153,7 +153,7 @@ test('it includes pre-release versions when requested', function () {
 - Version 1
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0', includePrerelease: true);
 
     expect($result->count())->toBe(2);
@@ -168,7 +168,7 @@ test('it handles versions without dates', function () {
 - Feature without date
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0');
 
     expect($result->count())->toBe(1);
@@ -177,7 +177,7 @@ MD;
 });
 
 test('it returns empty collection for empty changelog', function () {
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse('', '1.0.0', '2.0.0');
 
     expect($result)->toBeInstanceOf(ReleaseNotesCollection::class);
@@ -191,7 +191,7 @@ test('it returns empty collection when no versions match', function () {
 - Version 1
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '2.0.0', '3.0.0');
 
     expect($result->count())->toBe(0);
@@ -220,7 +220,7 @@ test('it handles multiple categories', function () {
 - Security patch
 MD;
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $result = $parser->parse($changelog, '1.0.0', '2.0.0');
 
     $releases = $result->getReleases();

--- a/tests/Unit/Analyzers/ReleaseNotes/GithubChangelogFetcherTest.php
+++ b/tests/Unit/Analyzers/ReleaseNotes/GithubChangelogFetcherTest.php
@@ -7,7 +7,7 @@ use Whatsdiff\Services\HttpService;
 
 test('it supports github.com URLs', function () {
     $httpService = Mockery::mock(HttpService::class);
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     expect($fetcher->supports('https://github.com/owner/repo', null))->toBeTrue();
@@ -15,7 +15,7 @@ test('it supports github.com URLs', function () {
 
 test('it does not support non-github URLs', function () {
     $httpService = Mockery::mock(HttpService::class);
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     expect($fetcher->supports('https://gitlab.com/owner/repo', null))->toBeFalse();
@@ -38,7 +38,7 @@ MD;
         ->once()
         ->andReturn($changelog);
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     $result = $fetcher->fetch(
@@ -75,7 +75,7 @@ MD;
         ->once()
         ->andReturn($changelog);
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     $result = $fetcher->fetch(
@@ -121,7 +121,7 @@ MD;
         ->once()
         ->andReturn($changelog);
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     $result = $fetcher->fetch(
@@ -155,7 +155,7 @@ MD;
         ->once()
         ->andReturn($changelog);
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     $result = $fetcher->fetch(
@@ -176,7 +176,7 @@ test('it returns null when repository URL is not github', function () {
     $httpService = Mockery::mock(HttpService::class);
     $httpService->shouldNotReceive('get');
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     $result = $fetcher->fetch(
@@ -197,7 +197,7 @@ test('it returns null when all fetches fail', function () {
     $httpService->shouldReceive('get')
         ->andThrow(new Exception('Not found'));
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     $result = $fetcher->fetch(
@@ -232,7 +232,7 @@ MD;
         ->once()
         ->andReturn($changelog);
 
-    $parser = new ChangelogParser();
+    $parser = new ChangelogParser;
     $fetcher = new GithubChangelogFetcher($httpService, $parser);
 
     $result = $fetcher->fetch(

--- a/tests/Unit/Analyzers/ReleaseNotes/GithubReleaseFetcherTest.php
+++ b/tests/Unit/Analyzers/ReleaseNotes/GithubReleaseFetcherTest.php
@@ -52,7 +52,7 @@ it('fetches releases from github api', function () {
         ])
         ->andReturn([
             'body' => json_encode($apiResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -115,7 +115,7 @@ it('filters releases by version range', function () {
         ->once()
         ->andReturn([
             'body' => json_encode($apiResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -152,7 +152,7 @@ it('excludes draft releases', function () {
         ->once()
         ->andReturn([
             'body' => json_encode($apiResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -187,7 +187,7 @@ it('excludes prerelease when not included', function () {
         ->once()
         ->andReturn([
             'body' => json_encode($apiResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -222,7 +222,7 @@ it('includes prerelease when requested', function () {
         ->once()
         ->andReturn([
             'body' => json_encode($apiResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -292,7 +292,7 @@ it('handles git@github.com URL format', function () {
         ->with(Mockery::pattern('#/repos/owner/repo/releases\?per_page=100&page=1$#'), Mockery::any())
         ->andReturn([
             'body' => json_encode($apiResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -327,7 +327,7 @@ it('handles versions without v prefix', function () {
         ->once()
         ->andReturn([
             'body' => json_encode($apiResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -350,7 +350,7 @@ it('returns null when api response is invalid json', function () {
         ->once()
         ->andReturn([
             'body' => 'invalid json',
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -393,7 +393,7 @@ it('fetches exact version when from and to are the same', function () {
         ->once()
         ->andReturn([
             'body' => json_encode($apiResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(
@@ -463,7 +463,7 @@ it('handles pagination when fetching releases', function () {
         ->with(Mockery::pattern('#per_page=100&page=1$#'), Mockery::any())
         ->andReturn([
             'body' => json_encode($firstPageResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $this->httpService
@@ -472,7 +472,7 @@ it('handles pagination when fetching releases', function () {
         ->with(Mockery::pattern('#per_page=100&page=2$#'), Mockery::any())
         ->andReturn([
             'body' => json_encode($secondPageResponse),
-            'headers' => []
+            'headers' => [],
         ]);
 
     $result = $this->fetcher->fetch(

--- a/tests/Unit/Analyzers/ReleaseNotes/LocalVendorChangelogFetcherTest.php
+++ b/tests/Unit/Analyzers/ReleaseNotes/LocalVendorChangelogFetcherTest.php
@@ -5,9 +5,9 @@ use Whatsdiff\Analyzers\ReleaseNotes\ChangelogParser;
 use Whatsdiff\Analyzers\ReleaseNotes\Fetchers\LocalVendorChangelogFetcher;
 
 beforeEach(function () {
-    $this->tempDir = sys_get_temp_dir() . '/whatsdiff-test-' . uniqid();
+    $this->tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
     mkdir($this->tempDir);
-    $this->parser = new ChangelogParser();
+    $this->parser = new ChangelogParser;
     $this->fetcher = new LocalVendorChangelogFetcher($this->parser);
 });
 
@@ -38,7 +38,7 @@ test('it fetches changelog from CHANGELOG.md', function () {
 - New feature
 MD;
 
-    file_put_contents($this->tempDir . '/CHANGELOG.md', $changelog);
+    file_put_contents($this->tempDir.'/CHANGELOG.md', $changelog);
 
     $result = $this->fetcher->fetch(
         'test/package',
@@ -63,7 +63,7 @@ test('it tries multiple changelog filenames', function () {
 MD;
 
     // Use CHANGELOG instead of CHANGELOG.md
-    file_put_contents($this->tempDir . '/CHANGELOG', $changelog);
+    file_put_contents($this->tempDir.'/CHANGELOG', $changelog);
 
     $result = $this->fetcher->fetch(
         'test/package',
@@ -108,7 +108,7 @@ test('it returns null when local path is null', function () {
 });
 
 test('it returns null for empty changelog file', function () {
-    file_put_contents($this->tempDir . '/CHANGELOG.md', '');
+    file_put_contents($this->tempDir.'/CHANGELOG.md', '');
 
     $result = $this->fetcher->fetch(
         'test/package',
@@ -124,8 +124,8 @@ test('it returns null for empty changelog file', function () {
 });
 
 test('it prefers CHANGELOG.md over other filenames', function () {
-    file_put_contents($this->tempDir . '/CHANGELOG.md', '## 2.0.0 - 2023-06-01' . PHP_EOL . '### Added' . PHP_EOL . '- From CHANGELOG.md');
-    file_put_contents($this->tempDir . '/HISTORY.md', '## 2.0.0 - 2023-06-01' . PHP_EOL . '### Added' . PHP_EOL . '- From HISTORY.md');
+    file_put_contents($this->tempDir.'/CHANGELOG.md', '## 2.0.0 - 2023-06-01'.PHP_EOL.'### Added'.PHP_EOL.'- From CHANGELOG.md');
+    file_put_contents($this->tempDir.'/HISTORY.md', '## 2.0.0 - 2023-06-01'.PHP_EOL.'### Added'.PHP_EOL.'- From HISTORY.md');
 
     $result = $this->fetcher->fetch(
         'test/package',

--- a/tests/Unit/Analyzers/ReleaseNotes/ReleaseNotesResolverTest.php
+++ b/tests/Unit/Analyzers/ReleaseNotes/ReleaseNotesResolverTest.php
@@ -9,7 +9,7 @@ use Whatsdiff\Data\ReleaseNote;
 use Whatsdiff\Data\ReleaseNotesCollection;
 
 beforeEach(function () {
-    $this->resolver = new ReleaseNotesResolver();
+    $this->resolver = new ReleaseNotesResolver;
 });
 
 it('adds fetchers to the chain', function () {
@@ -31,7 +31,7 @@ it('tries fetchers in order until one succeeds', function () {
             tagName: 'v1.1.0',
             title: 'Release',
             body: 'Body',
-            date: new DateTimeImmutable()
+            date: new DateTimeImmutable
         ),
     ]);
 
@@ -89,7 +89,7 @@ it('skips fetchers that do not support the source', function () {
             tagName: 'v1.1.0',
             title: 'Release',
             body: 'Body',
-            date: new DateTimeImmutable()
+            date: new DateTimeImmutable
         ),
     ]);
 
@@ -174,13 +174,13 @@ it('skips empty results and continues to next fetcher', function () {
     $fetcher1 = Mockery::mock(ReleaseNotesFetcherInterface::class);
     $fetcher2 = Mockery::mock(ReleaseNotesFetcherInterface::class);
 
-    $emptyCollection = new ReleaseNotesCollection();
+    $emptyCollection = new ReleaseNotesCollection;
     $validCollection = new ReleaseNotesCollection([
         new ReleaseNote(
             tagName: 'v1.1.0',
             title: 'Release',
             body: 'Body',
-            date: new DateTimeImmutable()
+            date: new DateTimeImmutable
         ),
     ]);
 
@@ -216,7 +216,7 @@ it('passes all parameters to fetchers correctly', function () {
             tagName: 'v2.1.0',
             title: 'Release',
             body: 'Body',
-            date: new DateTimeImmutable()
+            date: new DateTimeImmutable
         ),
     ]);
 

--- a/tests/Unit/Commands/ChangelogCommandTest.php
+++ b/tests/Unit/Commands/ChangelogCommandTest.php
@@ -32,7 +32,7 @@ beforeEach(function () {
         $this->errorHandler
     );
 
-    $application = new Application();
+    $application = new Application;
     $application->add($this->command);
 
     $this->commandTester = new CommandTester($this->command);

--- a/tests/Unit/Data/ReleaseNoteTest.php
+++ b/tests/Unit/Data/ReleaseNoteTest.php
@@ -40,7 +40,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $changes = $releaseNote->getChanges();
@@ -69,7 +69,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $fixes = $releaseNote->getFixes();
@@ -98,7 +98,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $breakingChanges = $releaseNote->getBreakingChanges();
@@ -122,7 +122,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $changes = $releaseNote->getChanges();
@@ -146,7 +146,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $fixes = $releaseNote->getFixes();
@@ -166,7 +166,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     // When unstructured, section methods return empty arrays
@@ -190,7 +190,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $changes = $releaseNote->getChanges();
@@ -215,7 +215,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $changes = $releaseNote->getChanges();
@@ -229,7 +229,7 @@ it('provides getter methods', function () {
         tagName: 'v1.0.0',
         title: 'My Release',
         body: 'Body content',
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getTitle())->toBe('My Release')
@@ -247,7 +247,7 @@ MD;
         tagName: 'v2.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getBreakingChanges())->toBe(['Major change A']);
@@ -265,7 +265,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getChanges())->toBe(['New feature X', 'Enhancement Y']);
@@ -283,7 +283,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getChanges())->toBe(['Feature A', 'Feature B']);
@@ -301,7 +301,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getChanges())->toBe(['Feature A', 'Feature B']);
@@ -319,7 +319,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getChanges())->toBe(['Enhancement A', 'Enhancement B']);
@@ -337,7 +337,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getFixes())->toBe(['Fixed issue A', 'Fixed issue B']);
@@ -355,7 +355,7 @@ MD;
         tagName: 'v2.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getBreakingChanges())->toBe(['Removed API X', 'Changed behavior Y']);
@@ -372,7 +372,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getChanges())->toBe([]);
@@ -399,7 +399,7 @@ MD;
         tagName: 'v2.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getChanges())->toBe(['New feature A', 'New feature B'])
@@ -424,7 +424,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $deprecated = $releaseNote->getDeprecated();
@@ -453,7 +453,7 @@ MD;
         tagName: 'v2.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $removed = $releaseNote->getRemoved();
@@ -482,7 +482,7 @@ MD;
         tagName: 'v1.0.1',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $security = $releaseNote->getSecurity();
@@ -525,7 +525,7 @@ MD;
         tagName: 'v2.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->getChanges())->toBe(['New feature X', 'Updated feature Y'])
@@ -547,7 +547,7 @@ MD;
         tagName: 'v1.0.0',
         title: 'Release',
         body: $body,
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     expect($releaseNote->isStructured())->toBeFalse()

--- a/tests/Unit/Data/ReleaseNotesCollectionTest.php
+++ b/tests/Unit/Data/ReleaseNotesCollectionTest.php
@@ -6,7 +6,7 @@ use Whatsdiff\Data\ReleaseNote;
 use Whatsdiff\Data\ReleaseNotesCollection;
 
 it('creates an empty collection', function () {
-    $collection = new ReleaseNotesCollection();
+    $collection = new ReleaseNotesCollection;
 
     expect($collection->count())->toBe(0)
         ->and($collection->isEmpty())->toBe(true)
@@ -40,14 +40,14 @@ it('collects all changes from multiple releases', function () {
         tagName: 'v1.0.0',
         title: 'Release 1',
         body: "## Changes\n- Feature A\n- Feature B",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v1.1.0',
         title: 'Release 2',
         body: "## Changes\n- Feature C\n- Feature D",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -67,14 +67,14 @@ it('collects all fixes from multiple releases', function () {
         tagName: 'v1.0.1',
         title: 'Patch 1',
         body: "## Fixes\n- Bug A\n- Bug B",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v1.0.2',
         title: 'Patch 2',
         body: "## Fixes\n- Bug C",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -89,14 +89,14 @@ it('collects all breaking changes from multiple releases', function () {
         tagName: 'v2.0.0',
         title: 'Major Release',
         body: "## Breaking Changes\n- Breaking A\n- Breaking B",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v3.0.0',
         title: 'Another Major',
         body: "## Breaking Changes\n- Breaking C",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -152,7 +152,7 @@ it('generates markdown with multiple releases', function () {
 });
 
 it('returns empty string when no releases in collection', function () {
-    $collection = new ReleaseNotesCollection();
+    $collection = new ReleaseNotesCollection;
 
     expect($collection->toMarkdown())->toBe('')
         ->and($collection->toSummarizedMarkdown())->toBe('');
@@ -163,14 +163,14 @@ it('generates summarized markdown with combined sections', function () {
         tagName: 'v1.0.0',
         title: 'Release 1',
         body: "## Changes\n- Feature A\n## Fixes\n- Bug A",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v1.1.0',
         title: 'Release 2',
         body: "## Changes\n- Feature B\n## Breaking Changes\n- Breaking A",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -193,14 +193,14 @@ it('is iterable', function () {
         tagName: 'v1.0.0',
         title: 'Release 1',
         body: 'Body 1',
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v1.1.0',
         title: 'Release 2',
         body: 'Body 2',
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -218,7 +218,7 @@ it('handles empty sections in summarized markdown', function () {
         tagName: 'v1.0.0',
         title: 'Release',
         body: 'Just some text without structured sections',
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release]);
@@ -237,7 +237,7 @@ it('does not duplicate title when tag name equals title in markdown', function (
         tagName: 'v1.0.0',
         title: 'v1.0.0',
         body: 'Release body',
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release]);
@@ -253,14 +253,14 @@ it('collects all deprecated items from multiple releases', function () {
         tagName: 'v1.5.0',
         title: 'Release 1',
         body: "## Deprecated\n- Old API method A\n- Legacy feature B",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v1.6.0',
         title: 'Release 2',
         body: "## Deprecated\n- Component C will be removed",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -279,14 +279,14 @@ it('collects all removed items from multiple releases', function () {
         tagName: 'v2.0.0',
         title: 'Major Release',
         body: "## Removed\n- Deleted deprecated API\n- Removed legacy support",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v2.1.0',
         title: 'Release 2',
         body: "## Removed\n- Removed old configuration format",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -305,14 +305,14 @@ it('collects all security items from multiple releases', function () {
         tagName: 'v1.0.1',
         title: 'Security Patch 1',
         body: "## Security\n- Fixed XSS vulnerability\n- Patched SQL injection",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v1.0.2',
         title: 'Security Patch 2',
         body: "## Security\n- Updated dependencies with security fixes",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -331,14 +331,14 @@ it('generates summarized markdown with all Keep a Changelog sections', function 
         tagName: 'v2.0.0',
         title: 'Major Release',
         body: "## Breaking Changes\n- Breaking A\n## Changes\n- Feature A\n## Fixes\n- Bug A\n## Deprecated\n- Old method A\n## Removed\n- Legacy feature A\n## Security\n- Security fix A",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $release2 = new ReleaseNote(
         tagName: 'v2.1.0',
         title: 'Minor Release',
         body: "## Changes\n- Feature B\n## Deprecated\n- Old method B\n## Security\n- Security fix B",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
@@ -369,7 +369,7 @@ it('returns empty arrays for new sections when no releases have them', function 
         tagName: 'v1.0.0',
         title: 'Release',
         body: "## Changes\n- Feature A",
-        date: new DateTimeImmutable()
+        date: new DateTimeImmutable
     );
 
     $collection = new ReleaseNotesCollection([$release]);

--- a/tests/Unit/Outputs/ReleaseNotes/ReleaseNotesJsonOutputTest.php
+++ b/tests/Unit/Outputs/ReleaseNotes/ReleaseNotesJsonOutputTest.php
@@ -8,9 +8,9 @@ use Whatsdiff\Data\ReleaseNotesCollection;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesJsonOutput;
 
 it('formats empty collection as json', function () {
-    $collection = new ReleaseNotesCollection();
-    $output = new BufferedOutput();
-    $formatter = new ReleaseNotesJsonOutput();
+    $collection = new ReleaseNotesCollection;
+    $output = new BufferedOutput;
+    $formatter = new ReleaseNotesJsonOutput;
 
     $formatter->format($collection, $output);
 
@@ -32,8 +32,8 @@ it('formats releases as json', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
-    $formatter = new ReleaseNotesJsonOutput();
+    $output = new BufferedOutput;
+    $formatter = new ReleaseNotesJsonOutput;
 
     $formatter->format($collection, $output);
 
@@ -65,8 +65,8 @@ it('formats multiple releases as json', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
-    $output = new BufferedOutput();
-    $formatter = new ReleaseNotesJsonOutput();
+    $output = new BufferedOutput;
+    $formatter = new ReleaseNotesJsonOutput;
 
     $formatter->format($collection, $output);
 
@@ -87,8 +87,8 @@ it('includes breaking changes in json', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
-    $formatter = new ReleaseNotesJsonOutput();
+    $output = new BufferedOutput;
+    $formatter = new ReleaseNotesJsonOutput;
 
     $formatter->format($collection, $output);
 

--- a/tests/Unit/Outputs/ReleaseNotes/ReleaseNotesMarkdownOutputTest.php
+++ b/tests/Unit/Outputs/ReleaseNotes/ReleaseNotesMarkdownOutputTest.php
@@ -8,13 +8,13 @@ use Whatsdiff\Data\ReleaseNotesCollection;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesMarkdownOutput;
 
 it('formats empty collection as markdown', function () {
-    $collection = new ReleaseNotesCollection();
-    $output = new BufferedOutput();
-    $formatter = new ReleaseNotesMarkdownOutput();
+    $collection = new ReleaseNotesCollection;
+    $output = new BufferedOutput;
+    $formatter = new ReleaseNotesMarkdownOutput;
 
     $formatter->format($collection, $output);
 
-    expect($output->fetch())->toBe('No release notes available.' . PHP_EOL);
+    expect($output->fetch())->toBe('No release notes available.'.PHP_EOL);
 });
 
 it('formats detailed markdown output', function () {
@@ -27,7 +27,7 @@ it('formats detailed markdown output', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesMarkdownOutput(summary: false);
 
     $formatter->format($collection, $output);
@@ -56,7 +56,7 @@ it('formats summarized markdown output', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesMarkdownOutput(summary: true);
 
     $formatter->format($collection, $output);
@@ -90,7 +90,7 @@ it('formats multiple releases in detailed mode', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesMarkdownOutput(summary: false);
 
     $formatter->format($collection, $output);
@@ -108,12 +108,12 @@ it('converts GitHub PR URLs to compact markdown links in detailed mode', functio
     $release = new ReleaseNote(
         tagName: 'v1.0.0',
         title: 'Release',
-        body: "Fix bug in https://github.com/laravel/framework/pull/57207",
+        body: 'Fix bug in https://github.com/laravel/framework/pull/57207',
         date: new DateTimeImmutable('2024-01-15')
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesMarkdownOutput(summary: false);
 
     $formatter->format($collection, $output);
@@ -128,12 +128,12 @@ it('converts GitHub issue URLs to compact markdown links in detailed mode', func
     $release = new ReleaseNote(
         tagName: 'v1.0.0',
         title: 'Release',
-        body: "Resolves https://github.com/symfony/symfony/issues/12345",
+        body: 'Resolves https://github.com/symfony/symfony/issues/12345',
         date: new DateTimeImmutable('2024-01-15')
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesMarkdownOutput(summary: false);
 
     $formatter->format($collection, $output);
@@ -153,7 +153,7 @@ it('converts GitHub URLs in summary mode', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesMarkdownOutput(summary: true);
 
     $formatter->format($collection, $output);
@@ -168,12 +168,12 @@ it('preserves existing markdown links with GitHub URLs', function () {
     $release = new ReleaseNote(
         tagName: 'v1.0.0',
         title: 'Release',
-        body: "[Add feature](https://github.com/owner/repo/pull/123) by @author",
+        body: '[Add feature](https://github.com/owner/repo/pull/123) by @author',
         date: new DateTimeImmutable('2024-01-15')
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesMarkdownOutput(summary: false);
 
     $formatter->format($collection, $output);
@@ -189,12 +189,12 @@ it('keeps non-GitHub URLs unchanged', function () {
     $release = new ReleaseNote(
         tagName: 'v1.0.0',
         title: 'Release',
-        body: "See https://laravel-news.com/article for details",
+        body: 'See https://laravel-news.com/article for details',
         date: new DateTimeImmutable('2024-01-15')
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesMarkdownOutput(summary: false);
 
     $formatter->format($collection, $output);

--- a/tests/Unit/Outputs/ReleaseNotes/ReleaseNotesTextOutputLinksTest.php
+++ b/tests/Unit/Outputs/ReleaseNotes/ReleaseNotesTextOutputLinksTest.php
@@ -38,7 +38,7 @@ it('does not add hyperlinks when ANSI is disabled', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesTextOutput(summary: false, useAnsi: false);
 
     $formatter->format($collection, $output);
@@ -241,7 +241,7 @@ it('does not convert GitHub URLs when ANSI is disabled', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesTextOutput(summary: false, useAnsi: false);
 
     $formatter->format($collection, $output);

--- a/tests/Unit/Outputs/ReleaseNotes/ReleaseNotesTextOutputTest.php
+++ b/tests/Unit/Outputs/ReleaseNotes/ReleaseNotesTextOutputTest.php
@@ -8,9 +8,9 @@ use Whatsdiff\Data\ReleaseNotesCollection;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesTextOutput;
 
 it('formats empty collection', function () {
-    $collection = new ReleaseNotesCollection();
-    $output = new BufferedOutput();
-    $formatter = new ReleaseNotesTextOutput();
+    $collection = new ReleaseNotesCollection;
+    $output = new BufferedOutput;
+    $formatter = new ReleaseNotesTextOutput;
 
     $formatter->format($collection, $output);
 
@@ -26,7 +26,7 @@ it('formats detailed output with releases', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesTextOutput(summary: false, useAnsi: false);
 
     $formatter->format($collection, $output);
@@ -58,7 +58,7 @@ it('formats summary output', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release1, $release2]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesTextOutput(summary: true, useAnsi: false);
 
     $formatter->format($collection, $output);
@@ -85,7 +85,7 @@ it('handles releases with breaking changes', function () {
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesTextOutput(summary: false, useAnsi: false);
 
     $formatter->format($collection, $output);
@@ -102,12 +102,12 @@ it('includes release URL when available', function () {
         tagName: 'v1.0.0',
         title: 'Release',
         body: 'Body',
-        date: new DateTimeImmutable(),
+        date: new DateTimeImmutable,
         url: 'https://github.com/owner/repo/releases/tag/v1.0.0'
     );
 
     $collection = new ReleaseNotesCollection([$release]);
-    $output = new BufferedOutput();
+    $output = new BufferedOutput;
     $formatter = new ReleaseNotesTextOutput(summary: false, useAnsi: false);
 
     $formatter->format($collection, $output);

--- a/tests/Unit/Outputs/Tui/ChangelogFormatterTest.php
+++ b/tests/Unit/Outputs/Tui/ChangelogFormatterTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Whatsdiff\Outputs\Tui\ChangelogFormatter;
 
 it('formats clickable URL without truncation when URL is short', function () {
-    $formatter = new ChangelogFormatter();
+    $formatter = new ChangelogFormatter;
     $reflection = new ReflectionClass($formatter);
     $method = $reflection->getMethod('formatClickableUrl');
     if (PHP_VERSION_ID < 80500) {
@@ -25,7 +25,7 @@ it('formats clickable URL without truncation when URL is short', function () {
 })->skip('URLs are broken in TUI for now');
 
 it('formats clickable URL with truncation when URL is long', function () {
-    $formatter = new ChangelogFormatter();
+    $formatter = new ChangelogFormatter;
     $reflection = new ReflectionClass($formatter);
     $method = $reflection->getMethod('formatClickableUrl');
     if (PHP_VERSION_ID < 80500) {
@@ -45,7 +45,7 @@ it('formats clickable URL with truncation when URL is long', function () {
 })->skip('URLs are broken in TUI for now');
 
 it('strips OSC 8 hyperlink codes when calculating visible length', function () {
-    $formatter = new ChangelogFormatter();
+    $formatter = new ChangelogFormatter;
     $reflection = new ReflectionClass($formatter);
     $stripMethod = $reflection->getMethod('stripAnsiCodes');
     if (PHP_VERSION_ID < 80500) {


### PR DESCRIPTION
Hardens CI in response to [Composer CVE-2026-45793](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2). Same pattern as [knotsphp/publicip#6](https://github.com/knotsphp/publicip/pull/6).

- Pin every action to a commit SHA across all 9 workflows
- Top-level `permissions: {}` (deny-all) on the 6 `build-*` workflows, `build-phar.yml`, and `update-changelog.yml`; `contents: read` on `test.yml` and `pint.yml`
- Drop the top-level `env: GITHUB_TOKEN` block from each `build-*` — it exposed the token to every step, incl. the downloaded static-PHP build scripts. `softprops/action-gh-release` picks up `github.token` via its input default
- `update-changelog.yml`: keeps `persist-credentials: true` explicitly (with rationale comment) because `git-auto-commit-action` pushes the CHANGELOG. All other checkouts: `persist-credentials: false`
- `pint.yml`: switch from `composer pint` (fix mode, no-op in CI) to `vendor/bin/pint --test`; narrow trigger to `pull_request` + `push: main`
- Add `.github/dependabot.yml` (monthly, grouped, labelled)
- Add `.github/CODEOWNERS`
