### PR TITLE
Default to JSON output when running inside an AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ whatsdiff --format=markdown
 whatsdiff --no-cache
 ```
 
+### AI Agent Auto-Detection
+When `whatsdiff` is invoked from inside an AI coding agent (Claude Code, Cursor, Gemini CLI, Codex,
+Copilot CLI, OpenCode, Replit, Devin, Augment, Amp, Antigravity, Pi, Kiro, etc.), it detects the
+environment via well-known variables (powered by
+[`laravel/agent-detector`](https://github.com/laravel/agent-detector)) and defaults `--format` to
+`json` so the agent receives structured output without parsing colored text. Passing `--format=text`
+(or any other explicit value) always overrides the auto-detected default.
+
 ## 🔧 Contributing
 This project follows PSR coding style. You can use `composer pint` to apply.
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "psr/container": "^2.0",
     "league/container": "^5.1",
     "php-mcp/server": "^2.0",
-    "react/promise": "^3.3"
+    "react/promise": "^3.3",
+    "laravel/agent-detector": "^2.0"
   },
   "require-dev": {
     "pestphp/pest": "^2.0|^3.0|^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d910b7d9f03d85d53dea4a5200f8790",
+    "content-hash": "2c2374b5d2f6c936d6e501bc5608dea0",
     "packages": [
         {
             "name": "composer/semver",
@@ -796,6 +796,68 @@
                 "source": "https://github.com/joetannenbaum/chewie/tree/0.1.11"
             },
             "time": "2024-12-07T01:53:54+00:00"
+        },
+        {
+            "name": "laravel/agent-detector",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/agent-detector.git",
+                "reference": "90694b9256099591cf9e55d08c18ba7a00bf099f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/agent-detector/zipball/90694b9256099591cf9e55d08c18ba7a00bf099f",
+                "reference": "90694b9256099591cf9e55d08c18ba7a00bf099f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.24.0",
+                "pestphp/pest": "^3.8.5|^4.1.0",
+                "pestphp/pest-plugin-type-coverage": "^3.0|^4.0.2",
+                "phpstan/phpstan": "^2.1.26",
+                "rector/rector": "^2.1.7",
+                "symfony/var-dumper": "^7.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Detect if code is running in an AI agent or automated development environment",
+            "homepage": "https://github.com/laravel/agent-detector",
+            "keywords": [
+                "Agent",
+                "ai",
+                "automation",
+                "claude",
+                "cursor",
+                "detection",
+                "devin",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/agent-detector/issues",
+                "source": "https://github.com/laravel/agent-detector"
+            },
+            "time": "2026-04-29T18:32:34+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/src/Application.php
+++ b/src/Application.php
@@ -62,7 +62,7 @@ class Application extends BaseApplication
      */
     public static function instantiateContainer(?AgentEnvironment $agentEnvironment = null): ContainerInterface
     {
-        $container = new Container();
+        $container = new Container;
 
         // Enable autowiring via ReflectionContainer delegate (with caching for performance)
         $container->delegate(new ReflectionContainer(true));

--- a/src/Application.php
+++ b/src/Application.php
@@ -21,6 +21,7 @@ use Whatsdiff\Commands\ChangelogCommand;
 use Whatsdiff\Commands\CheckCommand;
 use Whatsdiff\Commands\ConfigCommand;
 use Whatsdiff\Commands\TuiCommand;
+use Whatsdiff\Services\AgentEnvironment;
 use Whatsdiff\Services\AnalyzerRegistry;
 
 class Application extends BaseApplication
@@ -54,15 +55,18 @@ class Application extends BaseApplication
      * Create and configure the dependency injection container.
      * This method is shared between the CLI application and MCP server.
      */
-    public static function instantiateContainer(): ContainerInterface
+    public static function instantiateContainer(?AgentEnvironment $agentEnvironment = null): ContainerInterface
     {
-        $container = new Container;
+        $container = new Container();
 
         // Enable autowiring via ReflectionContainer delegate (with caching for performance)
         $container->delegate(new ReflectionContainer(true));
 
         // Register the container itself for services that need it
         $container->add(ContainerInterface::class, $container);
+
+        // Register the detected agent environment so commands can adapt their defaults.
+        $container->add(AgentEnvironment::class, $agentEnvironment ?? AgentEnvironment::detect());
 
         // Configure AnalyzerRegistry with package manager analyzers
         // Analyzers are lazy-loaded only when needed

--- a/src/Commands/AnalyseCommand.php
+++ b/src/Commands/AnalyseCommand.php
@@ -14,6 +14,7 @@ use Whatsdiff\Outputs\JsonOutput;
 use Whatsdiff\Outputs\MarkdownOutput;
 use Whatsdiff\Outputs\OutputFormatterInterface;
 use Whatsdiff\Outputs\TextOutput;
+use Whatsdiff\Services\AgentEnvironment;
 use Whatsdiff\Services\CacheService;
 use Whatsdiff\Services\DiffCalculator;
 
@@ -32,6 +33,7 @@ class AnalyseCommand extends Command
     public function __construct(
         private readonly CacheService $cacheService,
         private readonly DiffCalculator $diffCalculator,
+        private readonly AgentEnvironment $agentEnvironment,
     ) {
         parent::__construct();
     }
@@ -43,7 +45,7 @@ class AnalyseCommand extends Command
             ->addIgnoreLastOption()
             ->addFromOption('Commit hash, branch, or tag to compare from (older version)')
             ->addToOption('Commit hash, branch, or tag to compare to (newer version, defaults to HEAD)')
-            ->addFormatOption()
+            ->addFormatOption($this->agentEnvironment->defaultFormat())
             ->addNoCacheOption()
             ->addIncludeOption()
             ->addExcludeOption()
@@ -134,8 +136,8 @@ class AnalyseCommand extends Command
     private function getFormatter(string $format, bool $noAnsi): OutputFormatterInterface
     {
         return match ($format) {
-            'json' => new JsonOutput,
-            'markdown' => new MarkdownOutput,
+            'json' => new JsonOutput(),
+            'markdown' => new MarkdownOutput(),
             default => new TextOutput(! $noAnsi),
         };
     }

--- a/src/Commands/AnalyseCommand.php
+++ b/src/Commands/AnalyseCommand.php
@@ -136,8 +136,8 @@ class AnalyseCommand extends Command
     private function getFormatter(string $format, bool $noAnsi): OutputFormatterInterface
     {
         return match ($format) {
-            'json' => new JsonOutput(),
-            'markdown' => new MarkdownOutput(),
+            'json' => new JsonOutput,
+            'markdown' => new MarkdownOutput,
             default => new TextOutput(! $noAnsi),
         };
     }

--- a/src/Commands/AuditCommand.php
+++ b/src/Commands/AuditCommand.php
@@ -146,8 +146,8 @@ class AuditCommand extends Command
     private function renderResult(AuditResult $result, string $format, bool $noAnsi, OutputInterface $output): void
     {
         match ($format) {
-            'json' => (new AuditJsonOutput())->format($result, $output),
-            'markdown' => (new AuditMarkdownOutput())->format($result, $output),
+            'json' => (new AuditJsonOutput)->format($result, $output),
+            'markdown' => (new AuditMarkdownOutput)->format($result, $output),
             default => (new AuditTextOutput(! $noAnsi))->format($result, $output),
         };
     }

--- a/src/Commands/BetweenCommand.php
+++ b/src/Commands/BetweenCommand.php
@@ -10,11 +10,18 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Whatsdiff\Services\AgentEnvironment;
 
 #[AsCommand(name: 'between')]
 class BetweenCommand extends Command
 {
     use SharedCommandOptions;
+
+    public function __construct(
+        private readonly AgentEnvironment $agentEnvironment,
+    ) {
+        parent::__construct();
+    }
 
     protected function configure(): void
     {
@@ -32,7 +39,7 @@ class BetweenCommand extends Command
                 'The ending commit, branch, or tag to compare to (newer version, defaults to HEAD)',
                 'HEAD'
             )
-            ->addFormatOption()
+            ->addFormatOption($this->agentEnvironment->defaultFormat())
             ->addNoCacheOption()
             ->addIncludeOption()
             ->addExcludeOption()

--- a/src/Commands/ChangelogCommand.php
+++ b/src/Commands/ChangelogCommand.php
@@ -21,6 +21,7 @@ use Whatsdiff\Helpers\VersionNormalizer;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesJsonOutput;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesMarkdownOutput;
 use Whatsdiff\Outputs\ReleaseNotes\ReleaseNotesTextOutput;
+use Whatsdiff\Services\AgentEnvironment;
 use Whatsdiff\Services\CacheService;
 use Whatsdiff\Services\GitRepository;
 
@@ -38,6 +39,7 @@ class ChangelogCommand extends Command
         private readonly NpmRegistry $npmRegistry,
         private readonly CacheService $cacheService,
         private readonly ReleaseNotesResolver $releaseNotesResolver,
+        private readonly AgentEnvironment $agentEnvironment,
     ) {
         parent::__construct();
     }
@@ -65,7 +67,7 @@ class ChangelogCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Package manager type (composer or npm)'
             )
-            ->addFormatOption()
+            ->addFormatOption($this->agentEnvironment->defaultFormat())
             ->addOption(
                 'summary',
                 's',

--- a/src/Commands/SharedCommandOptions.php
+++ b/src/Commands/SharedCommandOptions.php
@@ -48,17 +48,19 @@ trait SharedCommandOptions
      * Add the --format option to the command.
      *
      * This option allows users to specify the output format (text, json, markdown).
+     * When invoked from an AI coding agent, callers can pass 'json' as the default
+     * so structured output is produced without an explicit --format flag.
      *
-     * @param  string  $default  Default format (typically 'text')
+     * @param  string|null  $default  Default format (defaults to 'text')
      */
-    protected function addFormatOption(string $default = 'text'): self
+    protected function addFormatOption(?string $default = null): self
     {
         return $this->addOption(
             'format',
             'f',
             InputOption::VALUE_REQUIRED,
-            'Output format (text, json, markdown)',
-            $default
+            'Output format (text, json, markdown). Defaults to json when running inside an AI agent.',
+            $default ?? 'text'
         );
     }
 

--- a/src/Services/AgentEnvironment.php
+++ b/src/Services/AgentEnvironment.php
@@ -11,8 +11,7 @@ final class AgentEnvironment
     public function __construct(
         public readonly bool $isAgent,
         public readonly ?string $agentName,
-    ) {
-    }
+    ) {}
 
     public static function detect(): self
     {

--- a/src/Services/AgentEnvironment.php
+++ b/src/Services/AgentEnvironment.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Services;
+
+use Laravel\AgentDetector\AgentDetector;
+
+final class AgentEnvironment
+{
+    public function __construct(
+        public readonly bool $isAgent,
+        public readonly ?string $agentName,
+    ) {
+    }
+
+    public static function detect(): self
+    {
+        $result = AgentDetector::detect();
+
+        return new self(
+            isAgent: $result->isAgent,
+            agentName: $result->isAgent ? ($result->name ?? 'unknown') : null,
+        );
+    }
+
+    public static function noAgent(): self
+    {
+        return new self(isAgent: false, agentName: null);
+    }
+
+    public function defaultFormat(): string
+    {
+        return $this->isAgent ? 'json' : 'text';
+    }
+}

--- a/src/whatsdiff-mcp.php
+++ b/src/whatsdiff-mcp.php
@@ -9,6 +9,7 @@ use Whatsdiff\Mcp\Tools\FindCompatibleVersionTool;
 use Whatsdiff\Mcp\Tools\GetAvailableUpgradesTool;
 use Whatsdiff\Mcp\Tools\GetDependencyConstraintsTool;
 use Whatsdiff\Mcp\Tools\GetReleaseNotesTool;
+use Whatsdiff\Services\AgentEnvironment;
 
 // Autoload dependencies
 if (! class_exists('\Composer\InstalledVersions')) {
@@ -18,8 +19,10 @@ if (! class_exists('\Composer\InstalledVersions')) {
 // Set up error handling (simplified for MCP server)
 error_reporting(0);
 
-// Initialize container with shared configuration
-$container = Application::instantiateContainer();
+// Initialize container with shared configuration.
+// MCP responses are already structured; skip agent detection so CLI defaults
+// (e.g. forcing JSON format) don't bleed into MCP tool output.
+$container = Application::instantiateContainer(AgentEnvironment::noAgent());
 
 // Build MCP server using the same container
 $server = Server::make()
@@ -48,5 +51,5 @@ $server = Server::make()
     ->build();
 
 // Create and start stdio transport
-$transport = new StdioServerTransport;
+$transport = new StdioServerTransport();
 $server->listen($transport);

--- a/src/whatsdiff-mcp.php
+++ b/src/whatsdiff-mcp.php
@@ -51,5 +51,5 @@ $server = Server::make()
     ->build();
 
 // Create and start stdio transport
-$transport = new StdioServerTransport();
+$transport = new StdioServerTransport;
 $server->listen($transport);

--- a/tests/Feature/AgentDetectionTest.php
+++ b/tests/Feature/AgentDetectionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Process\Process as SymfonyProcess;
+
+beforeEach(function () {
+    $this->tempDir = initTempDirectory();
+
+    // Build a 2-commit history with a composer.lock change so `analyse` has output.
+    $initial = generateComposerLock(['symfony/console' => 'v5.4.0']);
+    file_put_contents($this->tempDir.'/composer.lock', $initial);
+    runCommand('git add composer.lock', $this->tempDir);
+    runCommand('git commit -m "Initial composer.lock"', $this->tempDir);
+
+    $updated = generateComposerLock(['symfony/console' => 'v6.0.0']);
+    file_put_contents($this->tempDir.'/composer.lock', $updated);
+    runCommand('git add composer.lock', $this->tempDir);
+    runCommand('git commit -m "Update symfony/console"', $this->tempDir);
+});
+
+afterEach(function () {
+    cleanupTempDirectory($this->tempDir);
+});
+
+function runWhatsDiffWithEnv(array $args, string $cwd, array $env): SymfonyProcess
+{
+    $binPath = realpath(__DIR__.'/../../bin/whatsdiff');
+    $phpBinary = (new ExecutableFinder())->find('php');
+
+    if (! $phpBinary) {
+        throw new RuntimeException('PHP executable not found');
+    }
+
+    $process = new SymfonyProcess(
+        array_merge([$phpBinary, $binPath, '--no-interaction'], $args),
+        $cwd,
+        $env + ['PATH' => getenv('PATH') ?: ''],
+    );
+    $process->setTimeout(120);
+    $process->run();
+
+    return $process;
+}
+
+it('defaults to JSON output when CLAUDECODE is set', function () {
+    $process = runWhatsDiffWithEnv([], $this->tempDir, ['CLAUDECODE' => '1']);
+
+    expect($process->getExitCode())->toBe(0);
+
+    $output = trim($process->getOutput());
+    expect($output)->not->toBe('');
+
+    $decoded = json_decode($output, true);
+    expect(json_last_error())->toBe(JSON_ERROR_NONE);
+    expect($decoded)->toBeArray();
+});
+
+it('explicit --format=text overrides agent JSON default', function () {
+    $process = runWhatsDiffWithEnv(
+        ['--format=text', '--no-progress'],
+        $this->tempDir,
+        ['CLAUDECODE' => '1'],
+    );
+
+    expect($process->getExitCode())->toBe(0);
+
+    $output = $process->getOutput();
+    expect(json_decode($output, true))->toBeNull();
+    expect($output)->toContain('symfony/console');
+});
+
+it('stays in text mode when no agent env var is present', function () {
+    $process = runWhatsDiffWithEnv(['--no-progress'], $this->tempDir, []);
+
+    expect($process->getExitCode())->toBe(0);
+
+    $output = $process->getOutput();
+    expect(json_decode($output, true))->toBeNull();
+    expect($output)->toContain('symfony/console');
+});

--- a/tests/Feature/AgentDetectionTest.php
+++ b/tests/Feature/AgentDetectionTest.php
@@ -27,7 +27,7 @@ afterEach(function () {
 function runWhatsDiffWithEnv(array $args, string $cwd, array $env): SymfonyProcess
 {
     $binPath = realpath(__DIR__.'/../../bin/whatsdiff');
-    $phpBinary = (new ExecutableFinder())->find('php');
+    $phpBinary = (new ExecutableFinder)->find('php');
 
     if (! $phpBinary) {
         throw new RuntimeException('PHP executable not found');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -40,3 +40,32 @@
 */
 
 require_once __DIR__.'/Helpers.php';
+
+// Clear AI-agent env vars (see Laravel\AgentDetector\AgentDetector) so the test
+// suite stays deterministic even when CI itself runs inside an agent shell.
+foreach ([
+    'AI_AGENT',
+    'CURSOR_AGENT',
+    'GEMINI_CLI',
+    'CODEX_SANDBOX',
+    'CODEX_CI',
+    'CODEX_THREAD_ID',
+    'AUGMENT_AGENT',
+    'OPENCODE_CLIENT',
+    'OPENCODE',
+    'AMP_CURRENT_THREAD_ID',
+    'CLAUDECODE',
+    'CLAUDE_CODE',
+    'CLAUDE_CODE_IS_COWORK',
+    'REPL_ID',
+    'COPILOT_MODEL',
+    'COPILOT_ALLOW_ALL',
+    'COPILOT_GITHUB_TOKEN',
+    'COPILOT_CLI',
+    'ANTIGRAVITY_AGENT',
+    'PI_CODING_AGENT',
+    'KIRO_AGENT_PATH',
+] as $agentEnvVar) {
+    putenv($agentEnvVar);
+    unset($_ENV[$agentEnvVar], $_SERVER[$agentEnvVar]);
+}

--- a/tests/Unit/Commands/ChangelogCommandTest.php
+++ b/tests/Unit/Commands/ChangelogCommandTest.php
@@ -36,7 +36,7 @@ beforeEach(function () {
         AgentEnvironment::noAgent(),
     );
 
-    $application = new Application();
+    $application = new Application;
     $application->add($this->command);
 
     $this->commandTester = new CommandTester($this->command);

--- a/tests/Unit/Commands/ChangelogCommandTest.php
+++ b/tests/Unit/Commands/ChangelogCommandTest.php
@@ -8,6 +8,7 @@ use Whatsdiff\Analyzers\Registries\NpmRegistry;
 use Whatsdiff\Analyzers\Registries\PackagistRegistry;
 use Whatsdiff\Analyzers\ReleaseNotes\ReleaseNotesResolver;
 use Whatsdiff\Commands\ChangelogCommand;
+use Whatsdiff\Services\AgentEnvironment;
 use Whatsdiff\Services\CacheService;
 use Whatsdiff\Services\CommandErrorHandler;
 use Whatsdiff\Services\GitRepository;
@@ -28,11 +29,10 @@ beforeEach(function () {
         $this->npmRegistry,
         $this->cacheService,
         $this->releaseNotesResolver,
-        $this->versionNormalizer,
-        $this->errorHandler
+        AgentEnvironment::noAgent(),
     );
 
-    $application = new Application;
+    $application = new Application();
     $application->add($this->command);
 
     $this->commandTester = new CommandTester($this->command);

--- a/tests/Unit/Services/AgentEnvironmentTest.php
+++ b/tests/Unit/Services/AgentEnvironmentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Whatsdiff\Services\AgentEnvironment;
+
+afterEach(function () {
+    foreach (['CLAUDECODE', 'CLAUDE_CODE', 'CURSOR_AGENT', 'GEMINI_CLI', 'AI_AGENT'] as $envVar) {
+        putenv($envVar);
+        unset($_ENV[$envVar], $_SERVER[$envVar]);
+    }
+});
+
+test('returns no-agent when no known env var is set', function () {
+    $env = AgentEnvironment::detect();
+
+    expect($env->isAgent)->toBeFalse();
+    expect($env->agentName)->toBeNull();
+    expect($env->defaultFormat())->toBe('text');
+});
+
+test('detects Claude Code via CLAUDECODE env var', function () {
+    putenv('CLAUDECODE=1');
+
+    $env = AgentEnvironment::detect();
+
+    expect($env->isAgent)->toBeTrue();
+    expect($env->agentName)->toBe('claude');
+    expect($env->defaultFormat())->toBe('json');
+});
+
+test('detects Cursor via CURSOR_AGENT env var', function () {
+    putenv('CURSOR_AGENT=1');
+
+    $env = AgentEnvironment::detect();
+
+    expect($env->isAgent)->toBeTrue();
+    expect($env->agentName)->toBe('cursor');
+    expect($env->defaultFormat())->toBe('json');
+});
+
+test('AI_AGENT env var maps github-copilot to copilot', function () {
+    putenv('AI_AGENT=github-copilot');
+
+    $env = AgentEnvironment::detect();
+
+    expect($env->isAgent)->toBeTrue();
+    expect($env->agentName)->toBe('copilot');
+    expect($env->defaultFormat())->toBe('json');
+});
+
+test('noAgent static constructor produces a non-agent env', function () {
+    $env = AgentEnvironment::noAgent();
+
+    expect($env->isAgent)->toBeFalse();
+    expect($env->agentName)->toBeNull();
+    expect($env->defaultFormat())->toBe('text');
+});


### PR DESCRIPTION
## Summary

When `whatsdiff` is invoked by an AI coding agent (Claude Code, Cursor, Gemini CLI, Codex, Copilot CLI, OpenCode, Devin, Replit, Augment, Amp, Antigravity, Pi, Kiro, …), the default `--format` now flips from `text` to `json` so the agent receives structured output instead of parsing colored text and progress bars. Explicit `--format=...` always wins.

Detection is delegated to [`laravel/agent-detector`](https://github.com/laravel/agent-detector) (v2, MIT, dependency-free), the same package the Laravel ecosystem uses for PAO/Pest/PHPStan. It inspects well-known env vars (`CLAUDECODE`, `CLAUDE_CODE`, `CURSOR_AGENT`, `GEMINI_CLI`, `CODEX_*`, `OPENCODE`, `COPILOT_*`, `AI_AGENT`, …) and the `/opt/.devin` filesystem marker.

## What changed

- **New service** `Whatsdiff\Services\AgentEnvironment` — thin wrapper exposing `detect()`, `noAgent()`, and `defaultFormat()`. Centralizes the agent → default-format decision so the rest of the codebase doesn't depend on the third-party class directly.
- **DI container** (`Application::instantiateContainer`) registers an `AgentEnvironment` singleton. The method now accepts an optional override so callers (notably MCP) can pass `AgentEnvironment::noAgent()`.
- **Format-aware commands** (`analyse`, `between`, `changelog`) inject `AgentEnvironment` and pass `defaultFormat()` to `addFormatOption()`. `check`, `config`, and `tui` are untouched — they don't expose `--format`.
- **`SharedCommandOptions::addFormatOption()`** signature is backward-compatible (default param is now nullable, falls back to `'text'`).
- **MCP entrypoint** (`bin/whatsdiff-mcp`) passes `AgentEnvironment::noAgent()` so MCP tool responses are never re-shaped by CLI defaults.
- **Tests** — clear known agent env vars in `tests/Pest.php` for deterministic CI; new unit + feature coverage for the detection and override behavior; `ChangelogCommandTest` updated for the new 6-arg constructor.
- **Docs** — README gains a short "AI Agent Auto-Detection" subsection under Output Formats.

## Test plan

- [x] `vendor/bin/pest --parallel` — 347 passed, 2 skipped, 0 failed
- [x] `vendor/bin/phpstan analyse --memory-limit=512M` — no errors (level 5)
- [x] `vendor/bin/pint --preset psr12 --test` on all changed/new files — pass
- [x] Human shell smoke (`env -u CLAUDECODE …`) → text output with colors
- [x] `CLAUDECODE=1 ./bin/whatsdiff` → valid JSON (`jq .` succeeds)
- [x] `CLAUDECODE=1 ./bin/whatsdiff --format=text` → text output (explicit wins)
- [x] `CLAUDECODE=1 ./bin/whatsdiff between HEAD~1 HEAD` → JSON (trait change reaches every format-aware command)