### PR TITLE
Fix issue where `whatsdiff between` was not using the relative file path of the lock files

### DIFF
--- a/src/Services/DiffCalculator.php
+++ b/src/Services/DiffCalculator.php
@@ -50,9 +50,17 @@ class DiffCalculator
             return;
         }
 
+        $relativeCurrentDir = $this->git->getRelativeCurrentDir();
+
         foreach ($this->getActiveDependencyTypes() as $type) {
+            $filename = $type->getLockFileName();
+
+            if (! empty($relativeCurrentDir) && file_exists($filename)) {
+                $filename = $relativeCurrentDir . DIRECTORY_SEPARATOR . $filename;
+            }
+
             $this->dependencyFiles->push(
-                DependencyFile::create($type, $type->getLockFileName())
+                DependencyFile::create($type, $filename)
             );
         }
     }
@@ -282,23 +290,8 @@ class DiffCalculator
 
     private function initializeDependencyFiles(bool $ignoreLast): void
     {
-        // Initialize dependency files structure if not already done
         $this->initializeDependencyFilesStructure();
 
-        $relativeCurrentDir = $this->git->getRelativeCurrentDir();
-
-        // Adjust file paths relative to current directory and git root
-        $this->dependencyFiles = $this->dependencyFiles->map(function (DependencyFile $dependencyFile) use (
-            $relativeCurrentDir
-        ) {
-            if (! empty($relativeCurrentDir) && file_exists($dependencyFile->file)) {
-                return $dependencyFile->withFile($relativeCurrentDir.DIRECTORY_SEPARATOR.$dependencyFile->file);
-            }
-
-            return $dependencyFile;
-        });
-
-        // Check if files have been recently updated or have commit logs
         $this->dependencyFiles = $this->dependencyFiles->map(function (DependencyFile $dependencyFile) use (
             $ignoreLast
         ) {
@@ -547,16 +540,17 @@ class DiffCalculator
      */
     private function countPackageChangesForCustomCommits(): int
     {
+        $this->initializeDependencyFilesStructure();
+
         $totalCount = 0;
         [$fromHash, $toHash] = $this->resolveCommitHashes();
 
-        foreach ($this->getActiveDependencyTypes() as $type) {
-            $filename = $type->getLockFileName();
-            $toContent = $this->getFileContents($filename, $toHash);
-            $fromContent = $this->getFileContents($filename, $fromHash);
+        foreach ($this->dependencyFiles as $dependencyFile) {
+            $toContent = $this->getFileContents($dependencyFile->file, $toHash);
+            $fromContent = $this->getFileContents($dependencyFile->file, $fromHash);
 
             if (! empty($toContent)) {
-                $packageDiffs = $this->calculatePackageDiff($type, $toContent, $fromContent);
+                $packageDiffs = $this->calculatePackageDiff($dependencyFile->type, $toContent, $fromContent);
                 $totalCount += count($packageDiffs);
             }
         }
@@ -613,13 +607,14 @@ class DiffCalculator
      */
     private function processCustomCommitsWithProgress(Collection $diffs): \Generator
     {
+        $this->initializeDependencyFilesStructure();
+
         [$fromHash, $toHash] = $this->resolveCommitHashes();
 
-        foreach ($this->getActiveDependencyTypes() as $type) {
-            $filename = $type->getLockFileName();
+        foreach ($this->dependencyFiles as $dependencyFile) {
             $generator = $this->calculateDiffBetweenCommitsWithProgress(
-                $type,
-                $filename,
+                $dependencyFile->type,
+                $dependencyFile->file,
                 $fromHash,
                 $toHash,
                 $this->skipReleaseCount

--- a/src/Services/DiffCalculator.php
+++ b/src/Services/DiffCalculator.php
@@ -290,8 +290,10 @@ class DiffCalculator
 
     private function initializeDependencyFiles(bool $ignoreLast): void
     {
+        // Initialize dependency files structure if not already done
         $this->initializeDependencyFilesStructure();
 
+        // Check if files have been recently updated or have commit logs
         $this->dependencyFiles = $this->dependencyFiles->map(function (DependencyFile $dependencyFile) use (
             $ignoreLast
         ) {

--- a/src/Services/DiffCalculator.php
+++ b/src/Services/DiffCalculator.php
@@ -56,7 +56,7 @@ class DiffCalculator
             $filename = $type->getLockFileName();
 
             if (! empty($relativeCurrentDir) && file_exists($filename)) {
-                $filename = $relativeCurrentDir . DIRECTORY_SEPARATOR . $filename;
+                $filename = $relativeCurrentDir.DIRECTORY_SEPARATOR.$filename;
             }
 
             $this->dependencyFiles->push(

--- a/src/Services/DiffCalculator.php
+++ b/src/Services/DiffCalculator.php
@@ -56,7 +56,7 @@ class DiffCalculator
             $filename = $type->getLockFileName();
 
             if (! empty($relativeCurrentDir) && file_exists($filename)) {
-                $filename = $relativeCurrentDir.DIRECTORY_SEPARATOR.$filename;
+                $filename = str_replace('\\', '/', $relativeCurrentDir).'/'.$filename;
             }
 
             $this->dependencyFiles->push(

--- a/tests/Feature/BetweenCommandTest.php
+++ b/tests/Feature/BetweenCommandTest.php
@@ -172,3 +172,47 @@ it('handles invalid commit references', function () {
     expect($process->getExitCode())->toBe(Command::FAILURE);
     expect($process->getOutput().$process->getErrorOutput())->toContain('Error:');
 });
+
+it('compares composer dependencies between two commits from a subdirectory', function () {
+    $subDir = $this->tempDir.'/backend';
+    mkdir($subDir, 0755, true);
+
+    file_put_contents($subDir.'/composer.lock', generateComposerLock(['symfony/http-kernel' => 'v6.0.0']));
+    runCommand('git add backend/composer.lock', $this->tempDir);
+    runCommand('git commit -m "Initial backend/composer.lock"', $this->tempDir);
+    $firstCommit = trim(runCommand('git rev-parse HEAD', $this->tempDir));
+
+    file_put_contents($subDir.'/composer.lock', generateComposerLock(['symfony/http-kernel' => 'v6.4.0']));
+    runCommand('git add backend/composer.lock', $this->tempDir);
+    runCommand('git commit -m "Update symfony/http-kernel"', $this->tempDir);
+    $secondCommit = trim(runCommand('git rev-parse HEAD', $this->tempDir));
+
+    $process = runWhatsDiff(['between', $firstCommit, $secondCommit], $subDir);
+
+    expect($process->getExitCode())->toBe(Command::SUCCESS);
+    expect($process->getOutput())->toContain('symfony/http-kernel');
+    expect($process->getOutput())->toContain('v6.0.0');
+    expect($process->getOutput())->toContain('v6.4.0');
+});
+
+it('compares npm dependencies between two commits from a subdirectory', function () {
+    $subDir = $this->tempDir.'/frontend';
+    mkdir($subDir, 0755, true);
+
+    file_put_contents($subDir.'/package-lock.json', generatePackageLock(['react' => '18.0.0']));
+    runCommand('git add frontend/package-lock.json', $this->tempDir);
+    runCommand('git commit -m "Initial frontend/package-lock.json"', $this->tempDir);
+    $firstCommit = trim(runCommand('git rev-parse HEAD', $this->tempDir));
+
+    file_put_contents($subDir.'/package-lock.json', generatePackageLock(['react' => '18.3.0']));
+    runCommand('git add frontend/package-lock.json', $this->tempDir);
+    runCommand('git commit -m "Update react"', $this->tempDir);
+    $secondCommit = trim(runCommand('git rev-parse HEAD', $this->tempDir));
+
+    $process = runWhatsDiff(['between', $firstCommit, $secondCommit], $subDir);
+
+    expect($process->getExitCode())->toBe(Command::SUCCESS);
+    expect($process->getOutput())->toContain('react');
+    expect($process->getOutput())->toContain('18.0.0');
+    expect($process->getOutput())->toContain('18.3.0');
+});

--- a/tests/Feature/OutputFormatsTest.php
+++ b/tests/Feature/OutputFormatsTest.php
@@ -87,7 +87,7 @@ test('json format always returns valid JSON ', function () {
 
 test('json format returns valid JSON error on failure', function () {
     // Test in a non-git directory
-    $this->tempDir = sys_get_temp_dir().'/whatsdiff-non-git-'.uniqid();
+    $this->tempDir = sys_get_temp_dir().'/whatsdiff-non-git-'.bin2hex(random_bytes(5));
     mkdir($this->tempDir, 0755, true);
 
     $process = runWhatsDiff(['--format=json'], $this->tempDir);

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -7,7 +7,7 @@ use Symfony\Component\Process\Process as SymfonyProcess;
 
 function initTempDirectory(bool $initGit = true): string
 {
-    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.bin2hex(random_bytes(5));
     mkdir($tempDir, 0755, true);
 
     if ($initGit) {

--- a/tests/Unit/Analyzers/Registries/PackagistRegistryTest.php
+++ b/tests/Unit/Analyzers/Registries/PackagistRegistryTest.php
@@ -346,7 +346,7 @@ it('uses support.source as last resort when other sources not available', functi
 
 it('loads auth from local auth.json and applies automatically', function () {
     // Create temporary directory with auth.json
-    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.bin2hex(random_bytes(5));
     mkdir($tempDir);
 
     $authContent = [
@@ -398,8 +398,8 @@ it('loads auth from local auth.json and applies automatically', function () {
 
 it('loads auth from both local and global with local taking precedence', function () {
     // Create temporary directories
-    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
-    $homeDir = sys_get_temp_dir().'/whatsdiff-home-'.uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.bin2hex(random_bytes(5));
+    $homeDir = sys_get_temp_dir().'/whatsdiff-home-'.bin2hex(random_bytes(5));
     mkdir($tempDir);
     mkdir($homeDir);
     mkdir($homeDir.'/.composer');
@@ -469,8 +469,8 @@ it('loads auth from both local and global with local taking precedence', functio
 
 it('uses global auth when local auth.json does not exist', function () {
     // Create temporary directories
-    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
-    $homeDir = sys_get_temp_dir().'/whatsdiff-home-'.uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.bin2hex(random_bytes(5));
+    $homeDir = sys_get_temp_dir().'/whatsdiff-home-'.bin2hex(random_bytes(5));
     mkdir($tempDir);
     mkdir($homeDir);
     mkdir($homeDir.'/.composer');
@@ -525,7 +525,7 @@ it('uses global auth when local auth.json does not exist', function () {
 
 it('explicit auth options override auth.json', function () {
     // Create temporary directory with auth.json
-    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.bin2hex(random_bytes(5));
     mkdir($tempDir);
 
     $authContent = [
@@ -575,7 +575,7 @@ it('explicit auth options override auth.json', function () {
 
 it('does not apply auth when domain does not match auth.json', function () {
     // Create temporary directory with auth.json
-    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
+    $tempDir = sys_get_temp_dir().'/whatsdiff-test-'.bin2hex(random_bytes(5));
     mkdir($tempDir);
 
     $authContent = [

--- a/tests/Unit/Analyzers/ReleaseNotes/LocalVendorChangelogFetcherTest.php
+++ b/tests/Unit/Analyzers/ReleaseNotes/LocalVendorChangelogFetcherTest.php
@@ -5,7 +5,7 @@ use Whatsdiff\Analyzers\ReleaseNotes\ChangelogParser;
 use Whatsdiff\Analyzers\ReleaseNotes\Fetchers\LocalVendorChangelogFetcher;
 
 beforeEach(function () {
-    $this->tempDir = sys_get_temp_dir().'/whatsdiff-test-'.uniqid();
+    $this->tempDir = sys_get_temp_dir().'/whatsdiff-test-'.bin2hex(random_bytes(5));
     mkdir($this->tempDir);
     $this->parser = new ChangelogParser;
     $this->fetcher = new LocalVendorChangelogFetcher($this->parser);

--- a/tests/Unit/Services/AuditCalculatorTest.php
+++ b/tests/Unit/Services/AuditCalculatorTest.php
@@ -15,7 +15,7 @@ use Whatsdiff\Services\FixSuggestionResolver;
 use Whatsdiff\Services\GitRepository;
 
 beforeEach(function () {
-    $this->workingDir = sys_get_temp_dir().'/whatsdiff-audit-test-'.uniqid();
+    $this->workingDir = sys_get_temp_dir().'/whatsdiff-audit-test-'.bin2hex(random_bytes(5));
     mkdir($this->workingDir);
     $this->originalDir = getcwd();
     chdir($this->workingDir);


### PR DESCRIPTION
fixes #46 

The `between` command was ignoring relative paths when run from a subdirectory, which caused it to fail with "No recent changes and no commit logs found" even when lock files existed.

The root cause was that `processCustomCommitsWithProgress` and `countPackageChangesForCustomCommits` were independently resolving lock file names from the dependency types directly, bypassing the relative path adjustment that happens elsewhere. The normal flow worked because `initializeDependencyFiles` handled the path prepending, but that path was never hit when commit hashes were passed in.

The fix moves the relative path logic into `initializeDependencyFilesStructure` so it this function can be re-used in `processCustomCommitsWithProgress` and `countPackageChangesForCustomCommits` (because `initializeDependencyFiles` does more stuff that we don't need to run in those functions) and changed them so they use the `$this->dependencyFiles` rather than recalculating filenames from scratch. Also added feature tests covering both composer and npm subdirectory cases.