### PR TITLE
Allow illuminate/collections ^13 (Laravel 13 support)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "ext-dom": "*",
     "composer-runtime-api": "^2.2",
     "laravel/prompts": "^0.1|^0.2|^0.3",
-    "illuminate/collections": "^10.0|^11.0|^12.0",
+    "illuminate/collections": "^10.0|^11.0|^12.0|^13.0",
     "composer/semver": "^3.4",
     "saloonphp/saloon": "^4.0",
     "joetannenbaum/chewie": "0.1.11",


### PR DESCRIPTION
## What

Widen the `illuminate/collections` constraint to include `^13.0`:

```diff
- "illuminate/collections": "^10.0|^11.0|^12.0",
+ "illuminate/collections": "^10.0|^11.0|^12.0|^13.0",
```

## Why

This is the only constraint blocking whatsdiff from installing in a **Laravel 13** application — `composer require whatsdiff/whatsdiff` fails to resolve because the framework pulls `illuminate/collections ^13`. The analyzer/lockfile classes use only Collection's stable API, and the other framework-adjacent constraints (`symfony ^7.4|^8.0`, `laravel/prompts ^0.1|^0.2|^0.3`) already span Laravel 13.

## Notes

Enables consuming whatsdiff's `Whatsdiff\Analyzers\ComposerAnalyzer::calculateDiff()` in-process from a Laravel 13 app to compute dependency diffs.