### PR TITLE
Fix cpx execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,10 @@ jobs:
       - name: Run tests (Unix)
         if: matrix.os != 'windows-latest'
         run: ./vendor/bin/pest --ci --parallel --fail-on-deprecation
+
+      - name: Test cpx execution
+        if: matrix.os == 'ubuntu-latest' && matrix.php == '8.4'
+        run: |
+          composer global require cpx/cpx --no-interaction --prefer-dist
+          export PATH="$COMPOSER_HOME/vendor/bin:$PATH"
+          cpx whatsdiff/whatsdiff:dev-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}} --version

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Via [Composer](https://getcomposer.org/) global require command
 composer global require whatsdiff/whatsdiff
 ```
 
+Or run it without installing globally via [cpx](https://github.com/laravel/cpx):
+```bash
+cpx whatsdiff/whatsdiff
+```
+
 or by [downloading binaries](https://github.com/whatsdiff/whatsdiff/releases/latest) on the latest release, currently only these binaries are compiled on the CI:
 - macOS x86_64
 - macOS arm64

--- a/bin/whatsdiff
+++ b/bin/whatsdiff
@@ -1,6 +1,17 @@
 #!/usr/bin/env php
 <?php
 
-include $_composer_autoload_path ?? __DIR__ . '/../vendor/autoload.php';
+$autoloadPaths = array_filter([
+    $_composer_autoload_path ?? null,
+    __DIR__.'/../vendor/autoload.php',
+    __DIR__.'/../../../autoload.php',
+]);
+
+foreach ($autoloadPaths as $autoloadPath) {
+    if (is_file($autoloadPath)) {
+        require $autoloadPath;
+        break;
+    }
+}
 
 require __DIR__.'/../src/whatsdiff.php';

--- a/src/Analyzers/Registries/RegistryInterface.php
+++ b/src/Analyzers/Registries/RegistryInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Whatsdiff\Analyzers\Registries;
 
+use Whatsdiff\Analyzers\Exceptions\PackageInformationsException;
+use Whatsdiff\Data\SecurityAdvisory;
+
 /**
  * Interface for package registry clients.
  *
@@ -22,7 +25,7 @@ interface RegistryInterface
      * @param  array<string, mixed>  $options  Additional options (e.g., auth credentials, registry URL)
      * @return array<string, mixed> Package metadata
      *
-     * @throws \Whatsdiff\Analyzers\Exceptions\PackageInformationsException If package cannot be fetched
+     * @throws PackageInformationsException If package cannot be fetched
      */
     public function getPackageMetadata(string $package, array $options = []): array;
 
@@ -35,7 +38,7 @@ interface RegistryInterface
      * @param  array<string, mixed>  $options  Additional options (e.g., auth credentials, registry URL)
      * @return array<int, string> Array of version strings
      *
-     * @throws \Whatsdiff\Analyzers\Exceptions\PackageInformationsException If package cannot be fetched
+     * @throws PackageInformationsException If package cannot be fetched
      */
     public function getVersions(string $package, string $from, string $to, array $options = []): array;
 
@@ -53,7 +56,7 @@ interface RegistryInterface
      *
      * @param  array<string>  $packages  Package names
      * @param  array<string, mixed>  $options  Additional options
-     * @return array<string, array<\Whatsdiff\Data\SecurityAdvisory>> Advisories indexed by package name
+     * @return array<string, array<SecurityAdvisory>> Advisories indexed by package name
      */
     public function getSecurityAdvisories(array $packages, array $options = []): array;
 }

--- a/src/Commands/TuiCommand.php
+++ b/src/Commands/TuiCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Whatsdiff\Analyzers\Registries\NpmRegistry;
 use Whatsdiff\Analyzers\Registries\PackagistRegistry;
 use Whatsdiff\Analyzers\ReleaseNotes\ReleaseNotesResolver;
+use Whatsdiff\Data\DiffResult;
 use Whatsdiff\Outputs\Tui\TerminalUI;
 use Whatsdiff\Services\CacheService;
 use Whatsdiff\Services\ConfigService;
@@ -153,7 +154,7 @@ class TuiCommand extends Command
         return Command::FAILURE;
     }
 
-    private function convertToTuiFormat(\Whatsdiff\Data\DiffResult $result): array
+    private function convertToTuiFormat(DiffResult $result): array
     {
         $packages = [];
 

--- a/src/whatsdiff.php
+++ b/src/whatsdiff.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use NunoMaduro\Collision\Provider;
 use Whatsdiff\Application;
 
 // Autoload dependencies
@@ -11,7 +12,7 @@ if (! class_exists('\Composer\InstalledVersions')) {
 
 // Set up error handling
 if (class_exists('\NunoMaduro\Collision\Provider')) {
-    (new \NunoMaduro\Collision\Provider)->register();
+    (new Provider)->register();
 } else {
     error_reporting(0);
 }

--- a/tests/Feature/AnalyseCommand/PrivateComposerPackageTest.php
+++ b/tests/Feature/AnalyseCommand/PrivateComposerPackageTest.php
@@ -6,6 +6,7 @@ use League\Container\Container;
 use League\Container\ReflectionContainer;
 use Tests\Mocks\MockHttpService;
 use Tests\Mocks\TestServiceProvider;
+use Whatsdiff\Data\DiffResult;
 use Whatsdiff\Services\DiffCalculator;
 
 beforeEach(function () {
@@ -109,7 +110,7 @@ it('handles private composer packages with authentication', function () {
         chdir($originalDir);
     }
 
-    expect($result)->toBeInstanceOf(\Whatsdiff\Data\DiffResult::class);
+    expect($result)->toBeInstanceOf(DiffResult::class);
     expect($result->diffs)->toHaveCount(1);
     expect($result->diffs->first()->type->value)->toBe('composer');
 
@@ -169,7 +170,7 @@ it('handles private packages without authentication gracefully', function () {
         chdir($originalDir);
     }
 
-    expect($result)->toBeInstanceOf(\Whatsdiff\Data\DiffResult::class);
+    expect($result)->toBeInstanceOf(DiffResult::class);
     expect($result->diffs)->toHaveCount(1);
 
     $changes = $result->diffs->first()->changes;
@@ -244,7 +245,7 @@ it('prioritizes local auth.json over global auth.json', function () {
         chdir($originalDir);
     }
 
-    expect($result)->toBeInstanceOf(\Whatsdiff\Data\DiffResult::class);
+    expect($result)->toBeInstanceOf(DiffResult::class);
     expect($result->diffs)->toHaveCount(1);
 
     $changes = $result->diffs->first()->changes;

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -15,7 +15,7 @@ function initTempDirectory(bool $initGit = true): string
         $process->run();
 
         if (! $process->isSuccessful()) {
-            throw new \RuntimeException("Failed to initialize git repository: {$process->getErrorOutput()}");
+            throw new RuntimeException("Failed to initialize git repository: {$process->getErrorOutput()}");
         }
 
         $process = new SymfonyProcess(['git', 'config', 'user.email', 'test@example.com'], $tempDir);
@@ -103,7 +103,7 @@ function runCommand(string $command, ?string $cwd = null): string
 
             return $process->getOutput();
         }
-        throw new \RuntimeException("Command failed: {$command}\nOutput: {$process->getOutput()}\nError: {$process->getErrorOutput()}");
+        throw new RuntimeException("Command failed: {$command}\nOutput: {$process->getOutput()}\nError: {$process->getErrorOutput()}");
     }
 
     return $process->getOutput();
@@ -119,7 +119,7 @@ function runWhatsDiff(array $args = [], ?string $cwd = null): SymfonyProcess
     $phpBinary = $executableFinder->find('php');
 
     if (! $phpBinary) {
-        throw new \RuntimeException('PHP executable not found');
+        throw new RuntimeException('PHP executable not found');
     }
 
     // Build command array

--- a/tests/Integration/FakeGitRepositoryTest.php
+++ b/tests/Integration/FakeGitRepositoryTest.php
@@ -81,7 +81,7 @@ it('handles npm only changes with add, update, downgrade, and remove', function 
 
     // Debug output if null
     if ($result === null) {
-        throw new \Exception('JSON decode failed. Raw output: '.$output);
+        throw new Exception('JSON decode failed. Raw output: '.$output);
     }
 
     // Add Windows debugging for empty diffs
@@ -217,7 +217,7 @@ it('handles composer only changes', function () {
 
     // Debug output if null
     if ($result === null) {
-        throw new \Exception('JSON decode failed. Raw output: '.$output);
+        throw new Exception('JSON decode failed. Raw output: '.$output);
     }
 
     expect($result)->toBeArray();
@@ -303,7 +303,7 @@ it('handles both composer and npm changes across multiple commits', function () 
 
     // Debug output if null
     if ($result === null) {
-        throw new \Exception('JSON decode failed. Raw output: '.$output);
+        throw new Exception('JSON decode failed. Raw output: '.$output);
     }
 
     expect($result)->toBeArray();
@@ -348,7 +348,7 @@ it('handles pnpm only changes with add, update, downgrade, and remove', function
     $result = json_decode($output, true);
 
     if ($result === null) {
-        throw new \Exception('JSON decode failed. Raw output: '.$output);
+        throw new Exception('JSON decode failed. Raw output: '.$output);
     }
 
     expect($result)->toBeArray();
@@ -413,7 +413,7 @@ it('shows no changes when there are several commits without dependency updates',
 
     // Debug output if null
     if ($result === null) {
-        throw new \Exception('JSON decode failed. Raw output: '.$output);
+        throw new Exception('JSON decode failed. Raw output: '.$output);
     }
 
     expect($result)->toBeArray();

--- a/tests/Unit/Analyzers/Registries/NpmRegistryTest.php
+++ b/tests/Unit/Analyzers/Registries/NpmRegistryTest.php
@@ -65,7 +65,7 @@ it('throws exception on http error', function () {
     $this->httpService
         ->shouldReceive('get')
         ->once()
-        ->andThrow(new \Exception('Network error'));
+        ->andThrow(new Exception('Network error'));
 
     $this->registry->getPackageMetadata('lodash');
 })->throws(PackageInformationsException::class, 'Failed to fetch package information for lodash');
@@ -212,7 +212,7 @@ it('returns null when package metadata fetch fails', function () {
     $this->httpService
         ->shouldReceive('get')
         ->once()
-        ->andThrow(new \Exception('Network error'));
+        ->andThrow(new Exception('Network error'));
 
     $result = $this->registry->getRepositoryUrl('lodash');
 

--- a/tests/Unit/Analyzers/Registries/PackagistRegistryTest.php
+++ b/tests/Unit/Analyzers/Registries/PackagistRegistryTest.php
@@ -128,7 +128,7 @@ it('throws exception on http error', function () {
     $this->httpService
         ->shouldReceive('get')
         ->once()
-        ->andThrow(new \Exception('Network error'));
+        ->andThrow(new Exception('Network error'));
 
     $this->registry->getPackageMetadata('symfony/console');
 })->throws(PackageInformationsException::class, 'Failed to fetch package information for symfony/console');
@@ -261,7 +261,7 @@ it('returns null when package metadata fetch fails', function () {
     $this->httpService
         ->shouldReceive('get')
         ->once()
-        ->andThrow(new \Exception('Network error'));
+        ->andThrow(new Exception('Network error'));
 
     $result = $this->registry->getRepositoryUrl('symfony/console');
 

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use Composer\InstalledVersions;
+
 // if Pest 3.0 is installed, use the new `arch` function
-if (version_compare(Composer\InstalledVersions::getVersion('pestphp/pest'), '3.0.0', '>=')) {
+if (version_compare(InstalledVersions::getVersion('pestphp/pest'), '3.0.0', '>=')) {
     // deactivated the preset because what'sdiff logo use a "suspicious character"
     // arch('php')->preset()->php();
 


### PR DESCRIPTION
## Summary
- load Composer's vendor autoloader when the package bin is executed directly by cpx
- document cpx usage in the installation section
- add a CI smoke test for `cpx whatsdiff/whatsdiff:dev-<branch>`

## Test Plan
- `php -l bin/whatsdiff`
- `./vendor/bin/pint --test bin/whatsdiff`
- `composer update --no-interaction --prefer-dist && composer test` (local PHP 8.3-compatible dependency resolution; lockfile restored afterward)
- `cpx whatsdiff/whatsdiff:dev-fix/cpx-autoload --version`