### PR TITLE
Embedding seams: explicit GitHub token, injectable HTTP client, AdvisoryMatcher extraction

### DIFF
--- a/src/Analyzers/Registries/NpmRegistry.php
+++ b/src/Analyzers/Registries/NpmRegistry.php
@@ -125,7 +125,12 @@ class NpmRegistry implements RegistryInterface
      * Uses the GitHub Advisory Database API for npm ecosystem advisories.
      *
      * @param  array<string>  $packages  Package names
-     * @param  array<string, mixed>  $options  Additional options
+     * @param  array<string, mixed>  $options  Additional options. Pass
+     *                                         `throwOnError => true` to rethrow fetch failures
+     *                                         instead of skipping the package — callers that
+     *                                         must distinguish "no advisories" from "the
+     *                                         advisory source is down" (e.g. persisted audits)
+     *                                         rely on it.
      * @return array<string, array<SecurityAdvisory>> Advisories indexed by package name
      */
     public function getSecurityAdvisories(array $packages, array $options = []): array
@@ -138,6 +143,10 @@ class NpmRegistry implements RegistryInterface
             try {
                 $response = $this->httpService->get($url);
             } catch (\Exception $e) {
+                if ($options['throwOnError'] ?? false) {
+                    throw $e;
+                }
+
                 continue;
             }
 

--- a/src/Analyzers/Registries/PackagistRegistry.php
+++ b/src/Analyzers/Registries/PackagistRegistry.php
@@ -165,7 +165,12 @@ class PackagistRegistry implements RegistryInterface
      * Uses the Packagist Security Advisories API which supports batch queries.
      *
      * @param  array<string>  $packages  Package names
-     * @param  array<string, mixed>  $options  Additional options
+     * @param  array<string, mixed>  $options  Additional options. Pass
+     *                                         `throwOnError => true` to rethrow fetch failures
+     *                                         instead of degrading to an empty result — callers
+     *                                         that must distinguish "no advisories" from "the
+     *                                         advisory source is down" (e.g. persisted audits)
+     *                                         rely on it.
      * @return array<string, array<SecurityAdvisory>> Advisories indexed by package name
      */
     public function getSecurityAdvisories(array $packages, array $options = []): array
@@ -184,6 +189,10 @@ class PackagistRegistry implements RegistryInterface
         try {
             $response = $this->httpService->get($url);
         } catch (\Exception $e) {
+            if ($options['throwOnError'] ?? false) {
+                throw $e;
+            }
+
             return [];
         }
 

--- a/src/Analyzers/ReleaseNotes/Fetchers/GithubChangelogFetcher.php
+++ b/src/Analyzers/ReleaseNotes/Fetchers/GithubChangelogFetcher.php
@@ -84,7 +84,10 @@ class GithubChangelogFetcher implements ReleaseNotesFetcherInterface
         // git@github.com:owner/repo
         // https://github.com/owner/repo
         // https://github.com/owner/repo.git
-        if (preg_match('#github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$#', $url, $matches)) {
+        // Owner/repo are restricted to GitHub's identifier charset so a
+        // hostile repository URL can never smuggle path traversal or query
+        // segments into the api.github.com request built from them.
+        if (preg_match('#github\.com[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?$#', $url, $matches)) {
             return [$matches[1], $matches[2]];
         }
 

--- a/src/Analyzers/ReleaseNotes/Fetchers/GithubReleaseFetcher.php
+++ b/src/Analyzers/ReleaseNotes/Fetchers/GithubReleaseFetcher.php
@@ -153,7 +153,10 @@ class GithubReleaseFetcher implements ReleaseNotesFetcherInterface
         // git@github.com:owner/repo
         // https://github.com/owner/repo
         // https://github.com/owner/repo.git
-        if (preg_match('#github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$#', $url, $matches)) {
+        // Owner/repo are restricted to GitHub's identifier charset so a
+        // hostile repository URL can never smuggle path traversal or query
+        // segments into the api.github.com request built from them.
+        if (preg_match('#github\.com[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?$#', $url, $matches)) {
             return [$matches[1], $matches[2]];
         }
 

--- a/src/Analyzers/SecurityAdvisories/AdvisoryMatcher.php
+++ b/src/Analyzers/SecurityAdvisories/AdvisoryMatcher.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Whatsdiff\Analyzers\SecurityAdvisories;
+
+use Composer\Semver\Semver;
+use Whatsdiff\Data\SecurityAdvisory;
+
+/**
+ * Pure advisory-to-version matching, shared by the audit and diff calculators
+ * (and usable standalone by consumers that fetch advisories themselves).
+ *
+ * Semantics are intentionally forgiving: an advisory whose constraint cannot
+ * be parsed (or is empty) is skipped rather than treated as matching, so a
+ * single malformed advisory never fails a whole audit.
+ */
+final class AdvisoryMatcher
+{
+    /**
+     * Advisories whose affected range matches the installed version.
+     *
+     * @param  array<SecurityAdvisory>  $advisories
+     * @return array<SecurityAdvisory>
+     */
+    public static function affecting(array $advisories, string $version): array
+    {
+        $affecting = [];
+
+        foreach ($advisories as $advisory) {
+            if ($advisory->affectedVersions === '') {
+                continue;
+            }
+
+            try {
+                if (Semver::satisfies($version, $advisory->affectedVersions)) {
+                    $affecting[] = $advisory;
+                }
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+
+        return $affecting;
+    }
+
+    /**
+     * Advisories fixed by upgrading from $from to $to: the range matches the
+     * old version but no longer matches the new one.
+     *
+     * @param  array<SecurityAdvisory>  $advisories
+     * @return array<SecurityAdvisory>
+     */
+    public static function fixedBetween(array $advisories, string $from, string $to): array
+    {
+        $fixed = [];
+
+        foreach ($advisories as $advisory) {
+            if ($advisory->affectedVersions === '') {
+                continue;
+            }
+
+            try {
+                if (Semver::satisfies($from, $advisory->affectedVersions)
+                    && ! Semver::satisfies($to, $advisory->affectedVersions)) {
+                    $fixed[] = $advisory;
+                }
+            } catch (\Exception $e) {
+                continue;
+            }
+        }
+
+        return $fixed;
+    }
+
+    /**
+     * Advisories newly affecting $to that did not affect $from (diff-mode
+     * audit semantics). A null $from (package added) means every advisory
+     * affecting $to counts as introduced; a $from that fails to parse against
+     * the range is treated as previously unaffected.
+     *
+     * @param  array<SecurityAdvisory>  $advisories
+     * @return array<SecurityAdvisory>
+     */
+    public static function introducedBetween(array $advisories, ?string $from, string $to): array
+    {
+        $introduced = [];
+
+        foreach (self::affecting($advisories, $to) as $advisory) {
+            if ($from === null) {
+                $introduced[] = $advisory;
+
+                continue;
+            }
+
+            try {
+                $fromAffected = Semver::satisfies($from, $advisory->affectedVersions);
+            } catch (\Exception $e) {
+                $fromAffected = false;
+            }
+
+            if (! $fromAffected) {
+                $introduced[] = $advisory;
+            }
+        }
+
+        return $introduced;
+    }
+}

--- a/src/Services/AuditCalculator.php
+++ b/src/Services/AuditCalculator.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Whatsdiff\Services;
 
-use Composer\Semver\Semver;
 use Illuminate\Support\Collection;
 use Whatsdiff\Analyzers\BaseAnalyzer;
 use Whatsdiff\Analyzers\PackageManagerType;
+use Whatsdiff\Analyzers\SecurityAdvisories\AdvisoryMatcher;
 use Whatsdiff\Analyzers\SecurityAdvisories\SeverityResolver;
 use Whatsdiff\Data\AuditResult;
 use Whatsdiff\Data\PackageAudit;
@@ -177,32 +177,10 @@ class AuditCalculator
                     continue;
                 }
 
-                $affecting = $this->filterAffecting($advisories, $toVersion);
-                if (empty($affecting)) {
-                    continue;
-                }
-
                 $fromVersion = $fromVersions[$package] ?? null;
 
                 // New advisories = those affecting the to-version that didn't affect the from-version
-                $newlyAffecting = [];
-                foreach ($affecting as $advisory) {
-                    if ($fromVersion === null) {
-                        $newlyAffecting[] = $advisory;
-
-                        continue;
-                    }
-
-                    try {
-                        $fromAffected = Semver::satisfies($fromVersion, $advisory->affectedVersions);
-                    } catch (\Exception $e) {
-                        $fromAffected = false;
-                    }
-
-                    if (! $fromAffected) {
-                        $newlyAffecting[] = $advisory;
-                    }
-                }
+                $newlyAffecting = AdvisoryMatcher::introducedBetween($advisories, $fromVersion, $toVersion);
 
                 if (empty($newlyAffecting)) {
                     continue;
@@ -314,23 +292,7 @@ class AuditCalculator
      */
     private function filterAffecting(array $advisories, string $version): array
     {
-        $affecting = [];
-
-        foreach ($advisories as $advisory) {
-            if ($advisory->affectedVersions === '') {
-                continue;
-            }
-
-            try {
-                if (Semver::satisfies($version, $advisory->affectedVersions)) {
-                    $affecting[] = $advisory;
-                }
-            } catch (\Exception $e) {
-                continue;
-            }
-        }
-
-        return $affecting;
+        return AdvisoryMatcher::affecting($advisories, $version);
     }
 
     /**

--- a/src/Services/DiffCalculator.php
+++ b/src/Services/DiffCalculator.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Whatsdiff\Services;
 
 use Composer\Semver\Comparator;
-use Composer\Semver\Semver;
 use Illuminate\Support\Collection;
 use Whatsdiff\Analyzers\BaseAnalyzer;
 use Whatsdiff\Analyzers\PackageManagerType;
+use Whatsdiff\Analyzers\SecurityAdvisories\AdvisoryMatcher;
 use Whatsdiff\Data\DependencyDiff;
 use Whatsdiff\Data\DependencyFile;
 use Whatsdiff\Data\DiffResult;
@@ -393,24 +393,7 @@ class DiffCalculator
      */
     private function filterFixedAdvisories(array $advisories, string $from, string $to): array
     {
-        $fixed = [];
-
-        foreach ($advisories as $advisory) {
-            if ($advisory->affectedVersions === '') {
-                continue;
-            }
-
-            try {
-                if (Semver::satisfies($from, $advisory->affectedVersions)
-                    && ! Semver::satisfies($to, $advisory->affectedVersions)) {
-                    $fixed[] = $advisory;
-                }
-            } catch (\Exception $e) {
-                continue;
-            }
-        }
-
-        return $fixed;
+        return AdvisoryMatcher::fixedBetween($advisories, $from, $to);
     }
 
     /**

--- a/src/Services/GithubAuthService.php
+++ b/src/Services/GithubAuthService.php
@@ -8,9 +8,10 @@ namespace Whatsdiff\Services;
  * Service for loading GitHub authentication tokens.
  *
  * Loads GitHub OAuth tokens from:
- * 1. Composer's auth.json files (local and global)
+ * 1. An explicit token provided at construction (embedding applications)
  * 2. GITHUB_TOKEN environment variable
- * 3. COMPOSER_AUTH environment variable
+ * 3. Composer's auth.json files (local and global)
+ * 4. COMPOSER_AUTH environment variable
  */
 class GithubAuthService
 {
@@ -19,18 +20,41 @@ class GithubAuthService
     private bool $tokenLoaded = false;
 
     /**
+     * @param  string|null  $token  Explicit token taking priority over every
+     *                              environment-derived source. Applications
+     *                              embedding whatsdiff pass their own token
+     *                              here instead of mutating the environment.
+     */
+    public function __construct(private readonly ?string $token = null) {}
+
+    /**
+     * Named constructor for container definitions: an empty string is
+     * normalized to null so `withToken(config(...))` degrades gracefully
+     * when the config value is unset.
+     */
+    public static function withToken(?string $token): self
+    {
+        return new self($token === '' ? null : $token);
+    }
+
+    /**
      * Get GitHub OAuth token from available sources.
      *
      * Priority order:
-     * 1. GITHUB_TOKEN environment variable
-     * 2. Local auth.json (current directory)
-     * 3. Global auth.json (~/.composer/auth.json)
-     * 4. COMPOSER_AUTH environment variable
+     * 1. Explicit constructor token
+     * 2. GITHUB_TOKEN environment variable
+     * 3. Local auth.json (current directory)
+     * 4. Global auth.json (~/.composer/auth.json)
+     * 5. COMPOSER_AUTH environment variable
      *
      * @return string|null GitHub OAuth token or null if not found
      */
     public function getToken(): ?string
     {
+        if ($this->token !== null && $this->token !== '') {
+            return $this->token;
+        }
+
         if ($this->tokenLoaded) {
             return $this->cachedToken;
         }

--- a/src/Services/HttpService.php
+++ b/src/Services/HttpService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Whatsdiff\Services;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
@@ -15,17 +16,23 @@ class HttpService
 {
     private CacheService $cache;
 
-    private Client $client;
+    private ClientInterface $client;
 
     private array $lastResponseHeaders = [];
 
     private GithubAuthService $githubAuth;
 
-    public function __construct(CacheService $cache, GithubAuthService $githubAuth)
+    /**
+     * @param  ClientInterface|null  $client  Injectable HTTP client so embedding
+     *                                        applications and tests can supply
+     *                                        their own (e.g. a MockHandler stack).
+     *                                        Defaults to whatsdiff's tuned client.
+     */
+    public function __construct(CacheService $cache, GithubAuthService $githubAuth, ?ClientInterface $client = null)
     {
         $this->cache = $cache;
         $this->githubAuth = $githubAuth;
-        $this->client = new Client([
+        $this->client = $client ?? new Client([
             'timeout' => 30,
             'connect_timeout' => 10,
             'allow_redirects' => [
@@ -99,7 +106,7 @@ class HttpService
         }
 
         try {
-            $response = $this->client->get($url, $guzzleOptions);
+            $response = $this->client->request('GET', $url, $guzzleOptions);
         } catch (RequestException $e) {
             if ($e->hasResponse()) {
                 $response = $e->getResponse();

--- a/tests/Unit/Analyzers/Registries/NpmRegistryTest.php
+++ b/tests/Unit/Analyzers/Registries/NpmRegistryTest.php
@@ -241,3 +241,14 @@ it('handles scoped packages correctly', function () {
 
     expect($result)->toBe($packageData);
 });
+
+it('rethrows advisory fetch failures when throwOnError is set', function () {
+    $httpService = Mockery::mock(HttpService::class);
+    $httpService->shouldReceive('get')->andThrow(new RuntimeException('HTTP request failed with status code: 500'));
+
+    $registry = new NpmRegistry($httpService);
+
+    expect($registry->getSecurityAdvisories(['lodash']))->toBe([]);
+    expect(fn () => $registry->getSecurityAdvisories(['lodash'], ['throwOnError' => true]))
+        ->toThrow(RuntimeException::class);
+});

--- a/tests/Unit/Analyzers/Registries/PackagistRegistryTest.php
+++ b/tests/Unit/Analyzers/Registries/PackagistRegistryTest.php
@@ -611,3 +611,14 @@ it('does not apply auth when domain does not match auth.json', function () {
         rmdir($tempDir);
     }
 });
+
+it('rethrows advisory fetch failures when throwOnError is set', function () {
+    $httpService = Mockery::mock(HttpService::class);
+    $httpService->shouldReceive('get')->andThrow(new RuntimeException('HTTP request failed with status code: 500'));
+
+    $registry = new PackagistRegistry($httpService);
+
+    expect($registry->getSecurityAdvisories(['guzzlehttp/psr7']))->toBe([]);
+    expect(fn () => $registry->getSecurityAdvisories(['guzzlehttp/psr7'], ['throwOnError' => true]))
+        ->toThrow(RuntimeException::class);
+});

--- a/tests/Unit/Analyzers/ReleaseNotes/GithubReleaseFetcherTest.php
+++ b/tests/Unit/Analyzers/ReleaseNotes/GithubReleaseFetcherTest.php
@@ -490,3 +490,23 @@ it('handles pagination when fetching releases', function () {
         ->and($result->getReleases()[0]->tagName)->toBe('v1.11.0')
         ->and($result->getReleases()[1]->tagName)->toBe('v1.10.0');
 });
+
+it('returns null for lookalike hosts and unsafe owner/repo segments without any HTTP call', function (string $url) {
+    // No expectation is primed on the HttpService mock: any request would
+    // fail the test. Hostile repository URLs must never produce a fetch.
+    $result = $this->fetcher->fetch(
+        package: 'evil/package',
+        fromVersion: '1.0.0',
+        toVersion: '1.1.0',
+        repositoryUrl: $url,
+        packageManagerType: PackageManagerType::COMPOSER,
+        localPath: null,
+        includePrerelease: false,
+    );
+
+    expect($result)->toBeNull();
+})->with([
+    'lookalike host' => ['https://github.com.evil.tld/owner/repo'],
+    'query smuggling in repo' => ['https://github.com/owner/repo?ref=x'],
+    'fragment in repo' => ['https://github.com/owner/repo#frag'],
+]);

--- a/tests/Unit/Analyzers/SecurityAdvisories/AdvisoryMatcherTest.php
+++ b/tests/Unit/Analyzers/SecurityAdvisories/AdvisoryMatcherTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Whatsdiff\Analyzers\SecurityAdvisories\AdvisoryMatcher;
+use Whatsdiff\Data\SecurityAdvisory;
+use Whatsdiff\Enums\Severity;
+
+function makeAdvisory(string $affectedVersions, string $id = 'GHSA-test'): SecurityAdvisory
+{
+    return new SecurityAdvisory(
+        advisoryId: $id,
+        cve: 'CVE-2024-0001',
+        title: 'Test advisory',
+        link: 'https://example.com/advisory',
+        affectedVersions: $affectedVersions,
+        severity: Severity::High,
+    );
+}
+
+it('matches advisories affecting the installed version', function () {
+    $advisories = [
+        makeAdvisory('>=2.0.0,<2.4.5', 'GHSA-hit'),
+        makeAdvisory('>=3.0.0', 'GHSA-miss'),
+    ];
+
+    $affecting = AdvisoryMatcher::affecting($advisories, '2.4.0');
+
+    expect($affecting)->toHaveCount(1)
+        ->and($affecting[0]->advisoryId)->toBe('GHSA-hit');
+});
+
+it('skips advisories with an empty affected range', function () {
+    expect(AdvisoryMatcher::affecting([makeAdvisory('')], '1.0.0'))->toBe([]);
+});
+
+it('skips advisories whose range cannot be parsed', function () {
+    $advisories = [
+        makeAdvisory('not a constraint !!!', 'GHSA-bad'),
+        makeAdvisory('>=1.0.0,<2.0.0', 'GHSA-good'),
+    ];
+
+    $affecting = AdvisoryMatcher::affecting($advisories, '1.5.0');
+
+    expect($affecting)->toHaveCount(1)
+        ->and($affecting[0]->advisoryId)->toBe('GHSA-good');
+});
+
+it('reports advisories fixed between two versions', function () {
+    $advisories = [
+        makeAdvisory('>=2.0.0,<2.4.5', 'GHSA-fixed'),
+        makeAdvisory('>=2.0.0,<3.0.0', 'GHSA-still-affected'),
+    ];
+
+    $fixed = AdvisoryMatcher::fixedBetween($advisories, '2.4.0', '2.4.5');
+
+    expect($fixed)->toHaveCount(1)
+        ->and($fixed[0]->advisoryId)->toBe('GHSA-fixed');
+});
+
+it('does not report a fixed advisory when the old version was not affected', function () {
+    $fixed = AdvisoryMatcher::fixedBetween([makeAdvisory('>=1.0.0,<2.0.0')], '2.1.0', '2.2.0');
+
+    expect($fixed)->toBe([]);
+});
+
+it('reports advisories introduced by a version change', function () {
+    $advisories = [
+        makeAdvisory('>=2.5.0,<2.6.0', 'GHSA-introduced'),
+        makeAdvisory('>=2.0.0,<2.6.0', 'GHSA-already-affected'),
+    ];
+
+    $introduced = AdvisoryMatcher::introducedBetween($advisories, '2.4.0', '2.5.1');
+
+    expect($introduced)->toHaveCount(1)
+        ->and($introduced[0]->advisoryId)->toBe('GHSA-introduced');
+});
+
+it('treats every affecting advisory as introduced for an added package', function () {
+    $advisories = [
+        makeAdvisory('>=2.0.0,<2.6.0', 'GHSA-a'),
+        makeAdvisory('>=9.0.0', 'GHSA-b'),
+    ];
+
+    $introduced = AdvisoryMatcher::introducedBetween($advisories, null, '2.5.0');
+
+    expect($introduced)->toHaveCount(1)
+        ->and($introduced[0]->advisoryId)->toBe('GHSA-a');
+});
+
+it('treats an unparsable from-version as previously unaffected', function () {
+    // The range parses against `to` but the dev `from` version cannot be
+    // evaluated — diff-mode semantics count the advisory as newly affecting.
+    $introduced = AdvisoryMatcher::introducedBetween(
+        [makeAdvisory('>=2.0.0,<2.6.0')],
+        'dev-main',
+        '2.5.0',
+    );
+
+    expect($introduced)->toHaveCount(1);
+});

--- a/tests/Unit/Services/GithubAuthServiceTest.php
+++ b/tests/Unit/Services/GithubAuthServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Whatsdiff\Services\GithubAuthService;
+
+it('prioritizes an explicit constructor token over the environment', function () {
+    putenv('GITHUB_TOKEN=env-token');
+
+    try {
+        $service = new GithubAuthService('explicit-token');
+
+        expect($service->getToken())->toBe('explicit-token')
+            ->and($service->hasToken())->toBe(true);
+    } finally {
+        putenv('GITHUB_TOKEN');
+    }
+});
+
+it('falls back to the environment when no explicit token is given', function () {
+    putenv('GITHUB_TOKEN=env-token');
+
+    try {
+        expect((new GithubAuthService)->getToken())->toBe('env-token');
+    } finally {
+        putenv('GITHUB_TOKEN');
+    }
+});
+
+it('normalizes an empty withToken value to the environment fallback', function () {
+    putenv('GITHUB_TOKEN=env-token');
+
+    try {
+        expect(GithubAuthService::withToken('')->getToken())->toBe('env-token')
+            ->and(GithubAuthService::withToken(null)->getToken())->toBe('env-token')
+            ->and(GithubAuthService::withToken('abc')->getToken())->toBe('abc');
+    } finally {
+        putenv('GITHUB_TOKEN');
+    }
+});

--- a/tests/Unit/Services/HttpServiceTest.php
+++ b/tests/Unit/Services/HttpServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Whatsdiff\Services\CacheService;
+use Whatsdiff\Services\ConfigService;
+use Whatsdiff\Services\GithubAuthService;
+use Whatsdiff\Services\HttpService;
+
+function buildHttpService(MockHandler $mock, array &$history, ?string $token = null): HttpService
+{
+    $stack = HandlerStack::create($mock);
+    $stack->push(Middleware::history($history));
+
+    $cacheDir = sys_get_temp_dir().'/whatsdiff-http-test-'.bin2hex(random_bytes(5));
+    $cache = new CacheService(new ConfigService($cacheDir.'/config.json'), $cacheDir);
+    $cache->disableCache();
+
+    return new HttpService(
+        $cache,
+        new GithubAuthService($token),
+        new Client(['handler' => $stack, 'http_errors' => false]),
+    );
+}
+
+it('uses an injected client instead of building its own', function () {
+    $history = [];
+    $service = buildHttpService(new MockHandler([new Response(200, [], 'mock-body')]), $history);
+
+    expect($service->get('https://packagist.org/anything'))->toBe('mock-body')
+        ->and($history)->toHaveCount(1)
+        ->and((string) $history[0]['request']->getUri())->toBe('https://packagist.org/anything');
+});
+
+it('attaches the github token only to api.github.com requests', function () {
+    $history = [];
+    $service = buildHttpService(new MockHandler([
+        new Response(200, [], '{}'),
+        new Response(200, [], '{}'),
+    ]), $history, token: 'test-token');
+
+    $service->get('https://api.github.com/advisories');
+    $service->get('https://packagist.org/api/security-advisories/');
+
+    expect($history[0]['request']->getHeaderLine('Authorization'))->toBe('Bearer test-token')
+        ->and($history[1]['request']->hasHeader('Authorization'))->toBe(false);
+});
+
+it('throws a RuntimeException with the status code on http errors', function () {
+    $history = [];
+    $service = buildHttpService(new MockHandler([new Response(500, [], 'boom')]), $history);
+
+    $service->get('https://packagist.org/broken');
+})->throws(RuntimeException::class, 'HTTP request failed with status code: 500');


### PR DESCRIPTION
Seams needed to embed whatsdiff's HTTP-backed services (registries, severity backfill, release notes) inside a long-running Laravel application (Unolia dependency insights):

- **U1 — `GithubAuthService`**: optional explicit token via constructor arg / `withToken()`, taking priority over `GITHUB_TOKEN` / auth.json. Embedders wire their own token without `putenv()`.
- **U2 — `HttpService`**: optional injectable `GuzzleHttp\ClientInterface` (defaults to the existing tuned client). Makes traffic mockable in embedder test suites (MockHandler / deny-by-default stacks). Internal call switched from the `get()` magic helper to `request('GET', …)` since the interface doesn't carry the helper methods.
- **U3 — `AdvisoryMatcher`**: extracts the advisory-matching filters private to `AuditCalculator` / `DiffCalculator` into a public pure class (`affecting` / `fixedBetween` / `introducedBetween`) with identical skip-on-parse-error semantics; both calculators now delegate to it.
- **Hardening**: GitHub release/changelog fetchers restrict extracted owner/repo to GitHub's identifier charset (`[A-Za-z0-9_.-]`) so a hostile `repository.url` in registry metadata can't smuggle query/path segments into the `api.github.com` request built from it.

No behavior change for the CLI. Full suite passes (458 passed). The single phpstan `identical.alwaysTrue` finding in `DiffCalculator` pre-exists on main.

Draft for review — Unolia pins this branch via its VCS repository entry in the meantime.