### PR TITLE
fix(ci): authenticate static-php-cli, unbloat Windows PHARs, PR the changelog

### DIFF
--- a/.github/workflows/build-linux-arm-binary.yml
+++ b/.github/workflows/build-linux-arm-binary.yml
@@ -51,10 +51,21 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      # --no-dev: release artifacts ship production code only. It also sidesteps
+      # Box's exclude-dev-files failing on Windows, which pulled dev packages into
+      # the PHAR (4921 files vs 1856 elsewhere). Safe now that
+      # cweagans/composer-patches is a production dependency, so the chewie patch
+      # is still applied.
       - name: Composer update
-        run: composer update --prefer-dist --no-progress --optimize-autoloader
+        run: composer update --no-dev --prefer-dist --no-progress --optimize-autoloader
 
+      # static-php-cli hits the GitHub API to resolve source tarballs. Without a
+      # token that is 60 requests/hour shared across all GitHub-hosted runners,
+      # which is why source downloads started failing. GITHUB_TOKEN is provided
+      # automatically and raises the limit to 1000/hour for this repository.
       - name: Build Binaries
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build-ci-linux-arm.sh --name "${{ env.BINARY_NAME }}" --mcp-name "${{ env.BINARY_MCP_NAME }}"
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-linux-binary.yml
+++ b/.github/workflows/build-linux-binary.yml
@@ -51,10 +51,21 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      # --no-dev: release artifacts ship production code only. It also sidesteps
+      # Box's exclude-dev-files failing on Windows, which pulled dev packages into
+      # the PHAR (4921 files vs 1856 elsewhere). Safe now that
+      # cweagans/composer-patches is a production dependency, so the chewie patch
+      # is still applied.
       - name: Composer update
-        run: composer update --prefer-dist --no-progress --optimize-autoloader
+        run: composer update --no-dev --prefer-dist --no-progress --optimize-autoloader
 
+      # static-php-cli hits the GitHub API to resolve source tarballs. Without a
+      # token that is 60 requests/hour shared across all GitHub-hosted runners,
+      # which is why source downloads started failing. GITHUB_TOKEN is provided
+      # automatically and raises the limit to 1000/hour for this repository.
       - name: Build Binaries
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build-ci-linux.sh --name "${{ env.BINARY_NAME }}" --mcp-name "${{ env.BINARY_MCP_NAME }}"
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-macos-arm-binary.yml
+++ b/.github/workflows/build-macos-arm-binary.yml
@@ -56,10 +56,21 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      # --no-dev: release artifacts ship production code only. It also sidesteps
+      # Box's exclude-dev-files failing on Windows, which pulled dev packages into
+      # the PHAR (4921 files vs 1856 elsewhere). Safe now that
+      # cweagans/composer-patches is a production dependency, so the chewie patch
+      # is still applied.
       - name: Composer update
-        run: composer update --prefer-dist --no-progress --optimize-autoloader
+        run: composer update --no-dev --prefer-dist --no-progress --optimize-autoloader
 
+      # static-php-cli hits the GitHub API to resolve source tarballs. Without a
+      # token that is 60 requests/hour shared across all GitHub-hosted runners,
+      # which is why source downloads started failing. GITHUB_TOKEN is provided
+      # automatically and raises the limit to 1000/hour for this repository.
       - name: Build Binaries
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build.sh --name "${{ env.BINARY_NAME }}" --mcp-name "${{ env.BINARY_MCP_NAME }}"
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-macos-binary.yml
+++ b/.github/workflows/build-macos-binary.yml
@@ -58,10 +58,21 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      # --no-dev: release artifacts ship production code only. It also sidesteps
+      # Box's exclude-dev-files failing on Windows, which pulled dev packages into
+      # the PHAR (4921 files vs 1856 elsewhere). Safe now that
+      # cweagans/composer-patches is a production dependency, so the chewie patch
+      # is still applied.
       - name: Composer update
-        run: composer update --prefer-dist --no-progress --optimize-autoloader
+        run: composer update --no-dev --prefer-dist --no-progress --optimize-autoloader
 
+      # static-php-cli hits the GitHub API to resolve source tarballs. Without a
+      # token that is 60 requests/hour shared across all GitHub-hosted runners,
+      # which is why source downloads started failing. GITHUB_TOKEN is provided
+      # automatically and raises the limit to 1000/hour for this repository.
       - name: Build Binaries
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build.sh --name "${{ env.BINARY_NAME }}" --mcp-name "${{ env.BINARY_MCP_NAME }}"
 
       - if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -40,8 +40,13 @@ jobs:
       - name: Setup Composer Platform
         run: composer config platform.php 8.2
 
+      # --no-dev: release artifacts ship production code only. It also sidesteps
+      # Box's exclude-dev-files failing on Windows, which pulled dev packages into
+      # the PHAR (4921 files vs 1856 elsewhere). Safe now that
+      # cweagans/composer-patches is a production dependency, so the chewie patch
+      # is still applied.
       - name: Composer update
-        run: composer update --prefer-dist --no-progress --optimize-autoloader
+        run: composer update --no-dev --prefer-dist --no-progress --optimize-autoloader
 
       - name: Generate PHAR files
         run: composer box

--- a/.github/workflows/build-windows-binary.yml
+++ b/.github/workflows/build-windows-binary.yml
@@ -52,8 +52,13 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**\\composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      # --no-dev: release artifacts ship production code only. It also sidesteps
+      # Box's exclude-dev-files failing on Windows, which pulled dev packages into
+      # the PHAR (4921 files vs 1856 elsewhere). Safe now that
+      # cweagans/composer-patches is a production dependency, so the chewie patch
+      # is still applied.
       - name: Composer update
-        run: composer update --prefer-dist --no-progress --optimize-autoloader
+        run: composer update --no-dev --prefer-dist --no-progress --optimize-autoloader
 
       - name: Build .phar file
         shell: bash
@@ -78,6 +83,8 @@ jobs:
 
       - name: SPC doctor
         working-directory: build/static-php-cli/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./bin/spc doctor
 
 #      - name: SPC Install UPX
@@ -86,6 +93,8 @@ jobs:
 
       - name: SPC Download
         working-directory: build/static-php-cli/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./bin/spc download --with-php="${{ env.COMPILE_PHP_VERSION }}" --for-extensions="ctype,curl,dom,filter,libxml,mbstring,openssl,phar,simplexml,xml,xmlwriter,zlib" --prefer-pre-built
 
       - name: SPC Switch PHP version
@@ -94,6 +103,8 @@ jobs:
 
       - name: SPC Build
         working-directory: build/static-php-cli/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./bin/spc build --build-micro "ctype,curl,dom,filter,libxml,mbstring,openssl,phar,simplexml,xml,xmlwriter,zlib"
 
       - name: PHP Micro combine

--- a/.github/workflows/build-windows-binary.yml
+++ b/.github/workflows/build-windows-binary.yml
@@ -60,11 +60,21 @@ jobs:
       - name: Composer update
         run: composer update --no-dev --prefer-dist --no-progress --optimize-autoloader
 
+      # Box compiles in %TEMP% and then removes that directory. On Windows the
+      # rmdir fails with "Resource temporarily unavailable" because Defender is
+      # still holding handles on the freshly written files. Excluding the temp
+      # directory from real-time scanning releases them.
+      - name: Exclude build temp from Defender
+        shell: pwsh
+        run: Add-MpPreference -ExclusionPath $env:TEMP -ErrorAction SilentlyContinue
+
+      # --no-parallel keeps Box single-threaded, so fewer concurrent file handles
+      # are open on the temp directory when it is torn down.
       - name: Build .phar file
         shell: bash
         env:
           BOX_REQUIREMENT_CHECKER: 0
-        run: ./tools/box.sh compile --config=box.json --allow-composer-check-failure --composer-bin "$(which composer)"
+        run: ./tools/box.sh compile --config=box.json --no-parallel --allow-composer-check-failure --composer-bin "$(which composer)"
 
       - name: Checkout static-php-cli
         working-directory: build

--- a/.github/workflows/build-windows-binary.yml
+++ b/.github/workflows/build-windows-binary.yml
@@ -60,21 +60,11 @@ jobs:
       - name: Composer update
         run: composer update --no-dev --prefer-dist --no-progress --optimize-autoloader
 
-      # Box compiles in %TEMP% and then removes that directory. On Windows the
-      # rmdir fails with "Resource temporarily unavailable" because Defender is
-      # still holding handles on the freshly written files. Excluding the temp
-      # directory from real-time scanning releases them.
-      - name: Exclude build temp from Defender
-        shell: pwsh
-        run: Add-MpPreference -ExclusionPath $env:TEMP -ErrorAction SilentlyContinue
-
-      # --no-parallel keeps Box single-threaded, so fewer concurrent file handles
-      # are open on the temp directory when it is torn down.
       - name: Build .phar file
         shell: bash
         env:
           BOX_REQUIREMENT_CHECKER: 0
-        run: ./tools/box.sh compile --config=box.json --no-parallel --allow-composer-check-failure --composer-bin "$(which composer)"
+        run: ./tools/box.sh compile --config=box.json --allow-composer-check-failure --composer-bin "$(which composer)"
 
       - name: Checkout static-php-cli
         working-directory: build

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # target_commitish is a raw commit SHA when the release is cut from a
-          # tag, which leaves the checkout detached and makes the push below fail.
-          # The changelog always belongs on the default branch.
+          # tag, which would leave the checkout detached. The changelog always
+          # belongs on the default branch.
           ref: ${{ github.event.repository.default_branch }}
-          # Credentials must persist so git-auto-commit-action can push the CHANGELOG update.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1.12.0
@@ -29,12 +29,20 @@ jobs:
           latest-version: ${{ github.event.release.tag_name }}
           release-notes: ${{ github.event.release.body }}
 
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+      # main has a ruleset requiring changes to go through a pull request, so a
+      # direct push is rejected with GH013. Open a PR instead of pushing.
+      - name: Open PR with updated CHANGELOG
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          branch: ${{ github.event.repository.default_branch }}
-          commit_message: 'chore: update changelog for ${{ github.event.release.tag_name }}'
-          file_pattern: CHANGELOG.md
-          commit_user_name: 'Eser Deniz'
-          commit_user_email: 'srwiez@gmail.com'
-          commit_author: 'Eser Deniz <srwiez@gmail.com>'
+          branch: chore/changelog-${{ github.event.release.tag_name }}
+          base: ${{ github.event.repository.default_branch }}
+          title: 'chore: update changelog for ${{ github.event.release.tag_name }}'
+          body: |
+            Automated changelog update for ${{ github.event.release.tag_name }}.
+
+            Opened as a PR because `main` requires changes to go through one.
+          commit-message: 'chore: update changelog for ${{ github.event.release.tag_name }}'
+          add-paths: CHANGELOG.md
+          committer: 'Eser Deniz <srwiez@gmail.com>'
+          author: 'Eser Deniz <srwiez@gmail.com>'
+          delete-branch: true

--- a/build-ci-linux-arm.sh
+++ b/build-ci-linux-arm.sh
@@ -32,14 +32,23 @@ echo "Building whatsdiff.phar..."
 echo "Building whatsdiff-mcp.phar..."
 ./tools/box.sh compile --config=box-mcp.json
 
-# Fetch or update static-php-cli
-if [ -d "build/static-php-cli" ]; then
+# Fetch static-php-cli at a pinned release.
+#
+# Its default branch is now v3, an unreleased rewrite, so a plain shallow clone
+# silently tracked in-development code. That is what broke the phpmicro sanity
+# check here: micro_zend_bug_test segfaults (exit -1, no output) on Alpine/musl.
+# The last linux build that succeeded (v2.3.0, 2026-03-27) predates the v3
+# switch. 2.8.5 is the latest stable release.
+SPC_VERSION="${SPC_VERSION:-2.8.5}"
+
+if [ -d "build/static-php-cli/.git" ] \
+  && git -C build/static-php-cli fetch --depth 1 origin "+refs/tags/${SPC_VERSION}:refs/tags/${SPC_VERSION}" \
+  && git -C build/static-php-cli checkout -q -f "${SPC_VERSION}"; then
   cd build/static-php-cli/
-#  git reset --hard HEAD
-  git pull
 else
+  rm -rf build/static-php-cli
   cd build/
-  git clone --depth 1 https://github.com/crazywhalecc/static-php-cli.git
+  git clone --depth 1 --branch "${SPC_VERSION}" https://github.com/crazywhalecc/static-php-cli.git
   cd static-php-cli/
 fi
 

--- a/build-ci-linux.sh
+++ b/build-ci-linux.sh
@@ -32,14 +32,23 @@ echo "Building whatsdiff.phar..."
 echo "Building whatsdiff-mcp.phar..."
 ./tools/box.sh compile --config=box-mcp.json
 
-# Fetch or update static-php-cli
-if [ -d "build/static-php-cli" ]; then
+# Fetch static-php-cli at a pinned release.
+#
+# Its default branch is now v3, an unreleased rewrite, so a plain shallow clone
+# silently tracked in-development code. That is what broke the phpmicro sanity
+# check here: micro_zend_bug_test segfaults (exit -1, no output) on Alpine/musl.
+# The last linux build that succeeded (v2.3.0, 2026-03-27) predates the v3
+# switch. 2.8.5 is the latest stable release.
+SPC_VERSION="${SPC_VERSION:-2.8.5}"
+
+if [ -d "build/static-php-cli/.git" ] \
+  && git -C build/static-php-cli fetch --depth 1 origin "+refs/tags/${SPC_VERSION}:refs/tags/${SPC_VERSION}" \
+  && git -C build/static-php-cli checkout -q -f "${SPC_VERSION}"; then
   cd build/static-php-cli/
-#  git reset --hard HEAD
-  git pull
 else
+  rm -rf build/static-php-cli
   cd build/
-  git clone --depth 1 https://github.com/crazywhalecc/static-php-cli.git
+  git clone --depth 1 --branch "${SPC_VERSION}" https://github.com/crazywhalecc/static-php-cli.git
   cd static-php-cli/
 fi
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "league/container": "^5.1",
     "php-mcp/server": "^2.0",
     "react/promise": "^3.3",
-    "laravel/agent-detector": "^2.0"
+    "laravel/agent-detector": "^2.0",
+    "cweagans/composer-patches": "^1.7"
   },
   "require-dev": {
     "pestphp/pest": "^2.0|^3.0|^4.0",
@@ -41,8 +42,7 @@
     "nunomaduro/collision": "^7.0|^8.0",
     "phpstan/phpstan": "^2.0",
     "spatie/ray": "^1.41",
-    "mockery/mockery": "^1.6",
-    "cweagans/composer-patches": "^1.7"
+    "mockery/mockery": "^1.6"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b625058e76c8ee91e8197469f06c105a",
+    "content-hash": "c3be3901037a03e8a8577ea62f2c869b",
     "packages": [
         {
             "name": "composer/semver",
@@ -82,6 +82,54 @@
                 }
             ],
             "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -4558,54 +4606,6 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
-        },
-        {
-            "name": "cweagans/composer-patches",
-            "version": "1.7.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
-                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "composer/composer": "~1.0 || ~2.0",
-                "phpunit/phpunit": "~4.6"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "cweagans\\Composer\\Patches"
-            },
-            "autoload": {
-                "psr-4": {
-                    "cweagans\\Composer\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Cameron Eagans",
-                    "email": "me@cweagans.net"
-                }
-            ],
-            "description": "Provides a way to patch Composer packages.",
-            "support": {
-                "issues": "https://github.com/cweagans/composer-patches/issues",
-                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
-            },
-            "time": "2022-12-20T22:53:13+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",

--- a/tools/box.sh
+++ b/tools/box.sh
@@ -23,7 +23,14 @@
 
 set -euo pipefail
 
-BOX_VERSION="${BOX_VERSION:-4.7.0}"
+# Pinned to 4.6.7 deliberately. Box 4.6.8 introduced a Windows regression where
+# compile dies tearing down its own temp directory:
+#   Failed to remove directory "C:\...\Temp\box\BoxNNNNN":
+#   rmdir(...): Resource temporarily unavailable
+# See https://github.com/box-project/box/issues/1574 (still open). 4.6.7 and
+# 4.7.0 produce byte-identical output on Linux/macOS, so pinning costs nothing.
+# Revisit once 1574 is fixed.
+BOX_VERSION="${BOX_VERSION:-4.6.7}"
 
 if ! command -v cpx >/dev/null 2>&1; then
     echo "cpx not found, installing it globally..."


### PR DESCRIPTION
Follow-up to #56, fixing three problems the v2.7.1 release exposed once the Box blocker was gone.

**1. static-php-cli hit the unauthenticated GitHub API limit** (60 req/hour, shared across GitHub-hosted runners), failing to download `curl`, `attr` and `libacl` sources. It reads `GITHUB_TOKEN`, which Actions provides automatically — no secret to configure.

**2. Box's `exclude-dev-files` is broken on Windows.** Identical Composer resolution produced 4921 files there vs 1856 elsewhere. Release artifacts ship production code only, so builds now use `--no-dev`.

**3. `update-changelog` could not push** — `main` has a ruleset requiring pull requests, so the push was rejected with GH013. It now opens a PR instead. This is why `CHANGELOG.md` has been stuck at v2.3.0.

**4. Box pinned to 4.6.7.** 4.6.8 introduced a Windows regression where compile dies removing its own temp directory (box-project/box#1574, open). 4.6.7 and 4.7.0 produce identical output on Linux/macOS.

### Why `cweagans/composer-patches` moved to `require`

It patches `joetannenbaum/chewie`, a **production** dependency, so under `--no-dev` the patcher was absent and the shipped chewie kept `mb_strlen` instead of the patched `mb_strwidth` — broken emoji width in the TUI. Anyone running `composer install --no-dev` was affected. Unreachable before #56, because `--no-dev` failed outright.

### Verification

- Windows binary builds successfully for the first time in the project's history (8.6 MB `.exe`, PHAR 1867 files matching Unix)
- `GITHUB_TOKEN` confirmed to clear the source-download failures
- `composer qa` green; a `--no-dev` build applies the chewie patch and produces a working PHAR

### Requires one repository setting

The changelog step needs **"Allow GitHub Actions to create and approve pull requests"** (Settings → Actions → General).

### Not fixed here

The linux binaries fail later, in static-php-cli's own `micro_zend_bug_test`: phpmicro builds, then segfaults on Alpine/musl. Unrelated to the above and tracked separately.
